### PR TITLE
Add support for connection string based keys

### DIFF
--- a/src/NLog.Extensions.AzureStorage/NLog.Extensions.AzureStorage.csproj
+++ b/src/NLog.Extensions.AzureStorage/NLog.Extensions.AzureStorage.csproj
@@ -56,6 +56,7 @@
       <HintPath>..\packages\NLog.4.4.2\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>


### PR DESCRIPTION
Adds support for pulling connection strings from the Connection String section in an app config or azure app service as a fallback

This resolves #4 