### PR TITLE
Fix error caused by trying to batch insert entities with different partition keys.

### DIFF
--- a/src/NLog.Extensions.AzureStorage/NLogEntity.cs
+++ b/src/NLog.Extensions.AzureStorage/NLogEntity.cs
@@ -16,7 +16,7 @@ namespace NLog.Extensions.AzureStorage
         public string FullMessage { get; set; }
         public string MachineName { get; set; }
 
-        public NLogEntity(LogEventInfo logEvent, string layoutMessage, string machineName)
+        public NLogEntity(LogEventInfo logEvent, string layoutMessage, string machineName, string partitionKey)
         {
             FullMessage = layoutMessage;
             Level = logEvent.Level.Name;
@@ -34,7 +34,7 @@ namespace NLog.Extensions.AzureStorage
                 }
             }
             RowKey = string.Concat((DateTime.MaxValue.Ticks - DateTime.UtcNow.Ticks).ToString("d19"), "__", Guid.NewGuid().ToString());
-            PartitionKey = LoggerName;
+            PartitionKey = partitionKey;
         }
         public NLogEntity() { }
     }

--- a/src/NLog.Extensions.AzureStorage/TableStorageTarget.cs
+++ b/src/NLog.Extensions.AzureStorage/TableStorageTarget.cs
@@ -92,7 +92,7 @@ namespace NLog.Extensions.AzureStorage
 
             InitializeTable(tableNameFinal);
             var layoutMessage = RenderLogEvent(Layout, logEvent);
-            var entity = new NLogEntity(logEvent, layoutMessage, _machineName);
+            var entity = new NLogEntity(logEvent, layoutMessage, _machineName, logEvent.LoggerName);
             var insertOperation = TableOperation.Insert(entity);
             TableExecute(_table, insertOperation);
         }
@@ -134,7 +134,7 @@ namespace NLog.Extensions.AzureStorage
                     foreach (var asyncLogEventInfo in partitionBucket.Value)
                     {
                         var layoutMessage = RenderLogEvent(Layout, asyncLogEventInfo.LogEvent);
-                        var entity = new NLogEntity(asyncLogEventInfo.LogEvent, layoutMessage, _machineName);
+                        var entity = new NLogEntity(asyncLogEventInfo.LogEvent, layoutMessage, _machineName, partitionBucket.Key);
                         batch.Insert(entity);
                         if (batch.Count == 100)
                         {
@@ -145,10 +145,10 @@ namespace NLog.Extensions.AzureStorage
 
                     if (batch.Count > 0)
                         TableExecuteBatch(_table, batch);
-                }
 
-                foreach (var asyncLogEventInfo in tableBucket.Value)
-                    asyncLogEventInfo.Continuation(null);
+                    foreach (var asyncLogEventInfo in partitionBucket.Value)
+                        asyncLogEventInfo.Continuation(null);
+                }
             }
         }
 


### PR DESCRIPTION
It was throwing a System.ArgumentException: 'All entities in a given batch must have the same partition key.'