### PR TITLE
Add property for setting the LogTimeStamp format string. Also set the…

### DIFF
--- a/src/NLog.Extensions.AzureStorage/NLogEntity.cs
+++ b/src/NLog.Extensions.AzureStorage/NLogEntity.cs
@@ -16,13 +16,13 @@ namespace NLog.Extensions.AzureStorage
         public string FullMessage { get; set; }
         public string MachineName { get; set; }
 
-        public NLogEntity(LogEventInfo logEvent, string layoutMessage, string machineName)
+        public NLogEntity(LogEventInfo logEvent, string layoutMessage, string machineName, string logTimeStampFormat)
         {
             FullMessage = layoutMessage;
             Level = logEvent.Level.Name;
             LoggerName = logEvent.LoggerName;
             Message = logEvent.Message;
-            LogTimeStamp = logEvent.TimeStamp.ToString();
+            LogTimeStamp = logEvent.TimeStamp.ToString(logTimeStampFormat);
             MachineName = machineName;
             if(logEvent.Exception != null)
             {

--- a/src/NLog.Extensions.AzureStorage/TableStorageTarget.cs
+++ b/src/NLog.Extensions.AzureStorage/TableStorageTarget.cs
@@ -35,6 +35,8 @@ namespace NLog.Extensions.AzureStorage
         [RequiredParameter]
         public Layout TableName { get; set; }
 
+        public string LogTimeStampFormat { get; set; } = "O";
+
         public TableStorageTarget()
         {
             OptimizeBufferReuse = true;
@@ -91,7 +93,7 @@ namespace NLog.Extensions.AzureStorage
 
             InitializeTable(tableNameFinal);
             var layoutMessage = RenderLogEvent(Layout, logEvent);
-            var entity = new NLogEntity(logEvent, layoutMessage, _machineName);
+            var entity = new NLogEntity(logEvent, layoutMessage, _machineName, LogTimeStampFormat);
             var insertOperation = TableOperation.Insert(entity);
             TableExecute(_table, insertOperation);
         }
@@ -126,7 +128,7 @@ namespace NLog.Extensions.AzureStorage
                 foreach (var asyncLogEventInfo in tableBucket.Value)
                 {
                     var layoutMessage = RenderLogEvent(Layout, asyncLogEventInfo.LogEvent);
-                    var entity = new NLogEntity(asyncLogEventInfo.LogEvent, layoutMessage, _machineName);
+                    var entity = new NLogEntity(asyncLogEventInfo.LogEvent, layoutMessage, _machineName, LogTimeStampFormat);
                     batch.Insert(entity);
                     if (batch.Count == 100)
                     {


### PR DESCRIPTION
… default value to the [Rount-trip](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#Roundtrip) format "O" to make it more sortable.

NOTE: if you'd rather I left the default value how it was, just let me know and I'll make the change.