### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/src/NLog.Extensions.AzureAccessToken/NLog.Extensions.AzureAccessToken.csproj
+++ b/src/NLog.Extensions.AzureAccessToken/NLog.Extensions.AzureAccessToken.csproj
@@ -21,7 +21,15 @@
     <PackageReleaseNotes>
       Added support for SourceLink
     </PackageReleaseNotes>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />

--- a/src/NLog.Extensions.AzureBlobStorage/NLog.Extensions.AzureBlobStorage.csproj
+++ b/src/NLog.Extensions.AzureBlobStorage/NLog.Extensions.AzureBlobStorage.csproj
@@ -23,7 +23,15 @@
       Updated dependency to NLog 4.6.8
       Added support for SourceLink
     </PackageReleaseNotes>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <Compile Include="..\NLog.Extensions.AzureStorage\AzureStorageNameCache.cs" Link="AzureStorageNameCache.cs" />

--- a/src/NLog.Extensions.AzureCosmosTable/NLog.Extensions.AzureCosmosTable.csproj
+++ b/src/NLog.Extensions.AzureCosmosTable/NLog.Extensions.AzureCosmosTable.csproj
@@ -21,7 +21,15 @@
     <PackageReleaseNotes>
 Updated Microsoft.Azure.Cosmos.Table to version 1.0.7 (Better performance)
     </PackageReleaseNotes>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <Compile Include="..\NLog.Extensions.AzureStorage\AzureStorageNameCache.cs" Link="AzureStorageNameCache.cs" />

--- a/src/NLog.Extensions.AzureEventHub/NLog.Extensions.AzureEventHub.csproj
+++ b/src/NLog.Extensions.AzureEventHub/NLog.Extensions.AzureEventHub.csproj
@@ -22,7 +22,15 @@
     <PackageReleaseNotes>
 Updated dependency Microsoft.Azure.EventHubs ver. 4.2.0 (Bug fixes)
     </PackageReleaseNotes>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <Compile Include="..\NLog.Extensions.AzureStorage\SortHelpers.cs" Link="SortHelpers.cs" />

--- a/src/NLog.Extensions.AzureQueueStorage/NLog.Extensions.AzureQueueStorage.csproj
+++ b/src/NLog.Extensions.AzureQueueStorage/NLog.Extensions.AzureQueueStorage.csproj
@@ -22,7 +22,15 @@
       Updated dependency to NLog 4.6.8
       Added support for SourceLink
     </PackageReleaseNotes>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <Compile Include="..\NLog.Extensions.AzureStorage\AzureStorageNameCache.cs" Link="AzureStorageNameCache.cs" />


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
