### PR TITLE
BlobStorageTarget - Changed to Azure.Storage.Blobs with metadata and tags

### DIFF
--- a/src/NLog.Extensions.AzureBlobStorage/ICloudBlobService.cs
+++ b/src/NLog.Extensions.AzureBlobStorage/ICloudBlobService.cs
@@ -9,7 +9,7 @@ namespace NLog.Extensions.AzureStorage
 {
     interface ICloudBlobService
     {
-        void Connect(string connectionString);
+        void Connect(string connectionString, string serviceUri, string tenantIdentity, string resourceIdentity, IDictionary<string, string> blobMetadata, IDictionary<string, string> blobTags);
         Task AppendFromByteArrayAsync(string containerName, string blobName, string contentType, byte[] buffer, CancellationToken cancellationToken);
     }
 }

--- a/src/NLog.Extensions.AzureBlobStorage/NLog.Extensions.AzureBlobStorage.csproj
+++ b/src/NLog.Extensions.AzureBlobStorage/NLog.Extensions.AzureBlobStorage.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'net452' ">true</DisableImplicitFrameworkReferences>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <Version>2.4.0</Version>
+    <Version>3.0.0</Version>
 
     <Description>NLog BlobStorageTarget for writing to Azure Cloud Blob Storage</Description>
     <Authors>jdetmar</Authors>
@@ -19,27 +18,20 @@
     <RepositoryUrl>https://github.com/JDetmar/NLog.Extensions.AzureStorage.git</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>
-Updated Microsoft.Azure.Storage.Blob to version 11.2.2 (Bug fixes and performance)
+Changed to Azure.Storage.Blobs ver. 12.6.0, because Microsoft.Azure.Storage.Blob has been deprecated.
     </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\NLog.Extensions.AzureStorage\AzureStorageNameCache.cs" Link="AzureStorageNameCache.cs" />
-    <Compile Include="..\NLog.Extensions.AzureStorage\ConnectionStringHelper.cs" Link="ConnectionStringHelper.cs" />
     <Compile Include="..\NLog.Extensions.AzureStorage\SortHelpers.cs" Link="SortHelpers.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.2" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.0" />
     <PackageReference Include="NLog" Version="4.6.8" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Configuration" />
-    <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
   </ItemGroup>
 
 </Project>

--- a/test/NLog.Extensions.AzureAccessToken.Tests/NLog.Extensions.AzureAccessToken.Tests.csproj
+++ b/test/NLog.Extensions.AzureAccessToken.Tests/NLog.Extensions.AzureAccessToken.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/NLog.Extensions.AzureBlobStorage.Tests/CloudBlobServiceMock.cs
+++ b/test/NLog.Extensions.AzureBlobStorage.Tests/CloudBlobServiceMock.cs
@@ -10,11 +10,18 @@ namespace NLog.Extensions.AzureBlobStorage.Tests
     class CloudBlobServiceMock : ICloudBlobService
     {
         public Dictionary<KeyValuePair<string,string>, byte[]> AppendBlob { get; } = new Dictionary<KeyValuePair<string, string>, byte[]>();
+
         public string ConnectionString { get; private set; }
 
-        public void Connect(string connectionString)
+        public IDictionary<string, string> BlobMetadata { get; private set; }
+
+        public IDictionary<string, string> BlobTags { get; private set; }
+
+        public void Connect(string connectionString, string serviceUri, string tenantIdentity, string resourceIdentity, IDictionary<string, string> blobMetadata, IDictionary<string, string> blobTags)
         {
             ConnectionString = connectionString;
+            BlobMetadata = blobMetadata;
+            BlobTags = blobTags;
         }
 
         public Task AppendFromByteArrayAsync(string containerName, string blobName, string contentType, byte[] buffer, CancellationToken cancellationToken)

--- a/test/NLog.Extensions.AzureBlobStorage.Tests/NLog.Extensions.AzureBlobStorage.Tests.csproj
+++ b/test/NLog.Extensions.AzureBlobStorage.Tests/NLog.Extensions.AzureBlobStorage.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/NLog.Extensions.AzureCosmosTable.Tests/NLog.Extensions.AzureCosmosTable.Tests.csproj
+++ b/test/NLog.Extensions.AzureCosmosTable.Tests/NLog.Extensions.AzureCosmosTable.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/NLog.Extensions.AzureEventHub.Tests/NLog.Extensions.AzureEventHub.Tests.csproj
+++ b/test/NLog.Extensions.AzureEventHub.Tests/NLog.Extensions.AzureEventHub.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/NLog.Extensions.AzureQueueStorage.Tests/NLog.Extensions.AzureQueueStorage.Tests.csproj
+++ b/test/NLog.Extensions.AzureQueueStorage.Tests/NLog.Extensions.AzureQueueStorage.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/NLog.Extensions.AzureStorage.IntegrationTest/NLog.Extensions.AzureStorage.IntegrationTest.csproj
+++ b/test/NLog.Extensions.AzureStorage.IntegrationTest/NLog.Extensions.AzureStorage.IntegrationTest.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.6.7\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\src\packages\NLog.4.6.8\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/test/NLog.Extensions.AzureStorage.IntegrationTest/packages.config
+++ b/test/NLog.Extensions.AzureStorage.IntegrationTest/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="4.6.7" targetFramework="net461" />
+  <package id="NLog" version="4.6.8" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
https://www.nuget.org/packages/Microsoft.Azure.Storage.Blob/ is now marked as deprecated.

Updated to recommended nuget-package, and added support for blob-tags and blob-metadata:

```xml
    <target type="AzureBlobStorage"
            name="AzureEmulator"
            layout="${longdate:universalTime=true} ${level:uppercase=true} - ${logger}: ${message} ${exception:format=tostring}"
            connectionString="UseDevelopmentStorage=true;"
            container="${level}"
            blobName="${date:universalTime=true:format=yyyy-MM-dd}/${date:universalTime=true:format=HH}.log">
               <metadata name="mymeta" layout="mymetavalue" />   <!-- Multiple allowed -->
               <tag name="mytag" layout="mytagvalue" /> <!-- Multiple allowed -->
    </target>
```