### PR TITLE
QueueStorageTarget - Changed to Azure.Storage.Queues with support for metadata

### DIFF
--- a/src/NLog.Extensions.AzureBlobStorage/BlobStorageTarget.cs
+++ b/src/NLog.Extensions.AzureBlobStorage/BlobStorageTarget.cs
@@ -29,8 +29,19 @@ namespace NLog.Targets
 
         public Layout ConnectionString { get; set; }
 
+        /// <summary>
+        /// Alternative to ConnectionString
+        /// </summary>
         public Layout ServiceUri { get; set; }
+
+        /// <summary>
+        /// Alternative to ConnectionString
+        /// </summary>
         public Layout TenantIdentity { get; set; }
+
+        /// <summary>
+        /// Alternative to ConnectionString (Defaults to https://storage.azure.com when not set)
+        /// </summary>
         public Layout ResourceIdentity { get; set; }
 
         [RequiredParameter]

--- a/src/NLog.Extensions.AzureBlobStorage/NLog.Extensions.AzureBlobStorage.csproj
+++ b/src/NLog.Extensions.AzureBlobStorage/NLog.Extensions.AzureBlobStorage.csproj
@@ -19,6 +19,8 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>
 Changed to Azure.Storage.Blobs ver. 12.6.0, because Microsoft.Azure.Storage.Blob has been deprecated.
+
+ConnectionStringKey option has been removed.
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/NLog.Extensions.AzureQueueStorage/ICloudQueueService.cs
+++ b/src/NLog.Extensions.AzureQueueStorage/ICloudQueueService.cs
@@ -1,12 +1,12 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.Storage.Queue;
 
 namespace NLog.Extensions.AzureStorage
 {
     internal interface ICloudQueueService
     {
-        void Connect(string connectionString);
-        Task AddMessageAsync(string queueName, CloudQueueMessage queueMessage, CancellationToken cancellationToken);
+        void Connect(string connectionString, string serviceUri, string tenantIdentity, string resourceIdentity, IDictionary<string, string> queueMetadata);
+        Task AddMessageAsync(string queueName, string queueMessage, CancellationToken cancellationToken);
     }
 }

--- a/src/NLog.Extensions.AzureQueueStorage/NLog.Extensions.AzureQueueStorage.csproj
+++ b/src/NLog.Extensions.AzureQueueStorage/NLog.Extensions.AzureQueueStorage.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'net452' ">true</DisableImplicitFrameworkReferences>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <Version>2.4.0</Version>
+    <Version>3.0.0</Version>
 
     <Description>NLog QueueStorageTarget for writing to Azure Cloud Queue Storage</Description>
     <Authors>jdetmar</Authors>
@@ -19,27 +18,22 @@
     <RepositoryUrl>https://github.com/JDetmar/NLog.Extensions.AzureStorage.git</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>
-Updated Microsoft.Azure.Storage.Queue to version 11.2.2 (Bug fixes and performance)
+Changed to Azure.Storage.Queues ver. 12.4.2, since Microsoft.Azure.Storage.Queue is deprecated.
+
+ConnectionStringKey option has been removed.
     </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\NLog.Extensions.AzureStorage\AzureStorageNameCache.cs" Link="AzureStorageNameCache.cs" />
-    <Compile Include="..\NLog.Extensions.AzureStorage\ConnectionStringHelper.cs" Link="ConnectionStringHelper.cs" />
     <Compile Include="..\NLog.Extensions.AzureStorage\SortHelpers.cs" Link="SortHelpers.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.2.2" />
     <PackageReference Include="NLog" Version="4.6.8" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.4.2" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Configuration" />
-    <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
   </ItemGroup>
 
 </Project>

--- a/test/NLog.Extensions.AzureQueueStorage.Tests/CloudQueueServiceMock.cs
+++ b/test/NLog.Extensions.AzureQueueStorage.Tests/CloudQueueServiceMock.cs
@@ -2,17 +2,18 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.Storage.Queue;
 using NLog.Extensions.AzureStorage;
 
 namespace NLog.Extensions.AzureQueueStorage.Tests
 {
     class CloudQueueServiceMock : ICloudQueueService
     {
-        public Dictionary<string, CloudQueueMessage> MessagesAdded { get; } = new Dictionary<string, CloudQueueMessage>();
+        public Dictionary<string, string> MessagesAdded { get; } = new Dictionary<string, string>();
         public string ConnectionString { get; private set; }
 
-        public Task AddMessageAsync(string queueName, CloudQueueMessage queueMessage, CancellationToken cancellationToken)
+        public IDictionary<string, string> QueueMetadata { get; private set; }
+
+        public Task AddMessageAsync(string queueName, string queueMessage, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(ConnectionString))
                 throw new InvalidOperationException("CloudQueueService not connected");
@@ -22,9 +23,10 @@ namespace NLog.Extensions.AzureQueueStorage.Tests
             return Task.Delay(10, cancellationToken);
         }
 
-        public void Connect(string connectionString)
+        public void Connect(string connectionString, string serviceUri, string tenantIdentity, string resourceIdentity, IDictionary<string, string> queueMetadata)
         {
             ConnectionString = connectionString;
+            QueueMetadata = queueMetadata;
         }
 
         public string PeekLastAdded(string queueName)
@@ -33,7 +35,7 @@ namespace NLog.Extensions.AzureQueueStorage.Tests
             {
                 if (MessagesAdded.TryGetValue(queueName, out var queueMessage))
                 {
-                    return queueMessage.AsString;
+                    return queueMessage;
                 }
             }
 

--- a/test/NLog.Extensions.AzureQueueStorage.Tests/QueueStorageTargetTest.cs
+++ b/test/NLog.Extensions.AzureQueueStorage.Tests/QueueStorageTargetTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using NLog.Targets;
 using Xunit;
 
@@ -17,11 +18,14 @@ namespace NLog.Extensions.AzureQueueStorage.Tests
             queueStorageTarget.ConnectionString = "${var:ConnectionString}";
             queueStorageTarget.QueueName = "${logger}";
             queueStorageTarget.Layout = "${message}";
+            queueStorageTarget.QueueMetadata.Add(new TargetPropertyWithContext() { Name = "MyMeta", Layout = "MyMetaValue" });
             logConfig.AddRuleForAllLevels(queueStorageTarget);
             logFactory.Configuration = logConfig;
             logFactory.GetLogger("test").Info("Hello World");
             logFactory.Flush();
             Assert.Equal(nameof(QueueStorageTargetTest), cloudQueueService.ConnectionString);
+            Assert.Single(cloudQueueService.QueueMetadata);
+            Assert.Contains(new KeyValuePair<string, string>("MyMeta", "MyMetaValue"), cloudQueueService.QueueMetadata);
             Assert.Single(cloudQueueService.MessagesAdded);   // One queue
             Assert.Equal("Hello World", cloudQueueService.PeekLastAdded("test"));
         }


### PR DESCRIPTION
https://www.nuget.org/packages/Microsoft.Azure.Storage.Queue/ is now marked as deprecated.

Updated to recommended nuget-package, and added support for queue-metadata:

```xml
    <target type="AzureQueueStorage"
            name="AzureQueue"
            layout="${longdate:universalTime=true} ${level:uppercase=true} - ${logger}: ${message} ${exception:format=tostring}"
            connectionString="UseDevelopmentStorage=true;"
            queueName="NlogQueue">
               <metadata name="mymeta" layout="mymetavalue" />   <!-- Multiple allowed -->
    </target>
```
