### PR TITLE
BlobStorageTarget - Added support for roll when using cached=true in BlobName

### DIFF
--- a/src/NLog.Extensions.AzureBlobStorage/NLog.Extensions.AzureBlobStorage.csproj
+++ b/src/NLog.Extensions.AzureBlobStorage/NLog.Extensions.AzureBlobStorage.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
 
     <Description>NLog BlobStorageTarget for writing to Azure Cloud Blob Storage</Description>
     <Authors>jdetmar</Authors>
@@ -20,7 +20,9 @@
     <PackageReleaseNotes>
 Changed to Azure.Storage.Blobs ver. 12.6.0, because Microsoft.Azure.Storage.Blob has been deprecated.
 
-ConnectionStringKey option has been removed.
+ConnectionStringKey option has been removed. Instead use &amp;{configsetting} or &amp;{appsetting}
+
+Added experimental support for rolling BlobName by using cached=true.
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/test/NLog.Extensions.AzureBlobStorage.Tests/BlobStorageTargetTest.cs
+++ b/test/NLog.Extensions.AzureBlobStorage.Tests/BlobStorageTargetTest.cs
@@ -56,8 +56,45 @@ namespace NLog.Extensions.AzureBlobStorage.Tests
             }
             logFactory.Flush();
             Assert.Equal(2, cloudBlobService.AppendBlob.Count);   // Two partitions
-            Assert.NotEqual(string.Empty, cloudBlobService.PeekLastAppendBlob("info", "Test1"));
-            Assert.NotEqual(string.Empty, cloudBlobService.PeekLastAppendBlob("debug", "Test2"));
+            Assert.NotNull(cloudBlobService.PeekLastAppendBlob("info", "Test1"));
+            Assert.NotNull(cloudBlobService.PeekLastAppendBlob("debug", "Test2"));
+        }
+
+        [Fact]
+        public void RollOnBlockCountExceedsLimit()
+        {
+            var logFactory = new LogFactory();
+            var logConfig = new Config.LoggingConfiguration(logFactory);
+            logConfig.Variables["ConnectionString"] = nameof(BlobStorageTargetTest);
+            var cloudBlobService = new CloudBlobServiceMock();
+            var logEventInfo = LogEventInfo.CreateNullEvent();
+            var blobStorageTarget = new BlobStorageTarget(cloudBlobService);
+            blobStorageTarget.ConnectionString = "${var:ConnectionString}";
+            blobStorageTarget.Container = "${level}";
+            blobStorageTarget.BlobName = "${logger}_${sequenceid:cached=true}";
+            blobStorageTarget.Layout = "${message}";
+            logConfig.AddRuleForAllLevels(blobStorageTarget);
+            logFactory.Configuration = logConfig;
+
+            var logEvent1 = LogEventInfo.Create(LogLevel.Info, null, "Hello");
+            logFactory.GetLogger("Test1").Log(logEvent1);
+            logFactory.Flush();
+            Assert.Contains("Hello", cloudBlobService.PeekLastAppendBlob("info", "Test1_" + logEvent1.SequenceID.ToString()));
+            var logEvent2 = LogEventInfo.Create(LogLevel.Info, null, "Goodbye");
+            logFactory.GetLogger("Test1").Log(logEvent2);
+            logFactory.Flush();
+            Assert.Contains("Goodbye", cloudBlobService.PeekLastAppendBlob("info", "Test1_" + logEvent1.SequenceID.ToString()));
+
+            cloudBlobService.FirstBlobNameHasBlockCountExceeded = true;
+
+            var logEvent3 = LogEventInfo.Create(LogLevel.Info, null, "Hello Roll");
+            logFactory.GetLogger("Test1").Log(logEvent3);
+            logFactory.Flush();
+            Assert.Contains("Hello Roll", cloudBlobService.PeekLastAppendBlob("info", "Test1_" + logEvent3.SequenceID.ToString()));
+            var logEvent4 = LogEventInfo.Create(LogLevel.Info, null, "Goodbye Roll");
+            logFactory.GetLogger("Test1").Log(logEvent4);
+            logFactory.Flush();
+            Assert.Contains("Goodbye Roll", cloudBlobService.PeekLastAppendBlob("info", "Test1_" + logEvent3.SequenceID.ToString()));
         }
     }
 }


### PR DESCRIPTION
Trying to resolve  #91 by allowing this:

`"${date:universalTime=true:format=yyyy-MM-dd}/Test/${logger:shortName=true}_${date:universalTime=true:format=HH:cached=true}.log"`