### PR TITLE
AzureCosmosTable - Support override of LogTimeStamp using first contextproperty

### DIFF
--- a/src/NLog.Extensions.AzureCosmosTable/NLog.Extensions.AzureCosmosTable.csproj
+++ b/src/NLog.Extensions.AzureCosmosTable/NLog.Extensions.AzureCosmosTable.csproj
@@ -5,7 +5,7 @@
     <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' ">true</DisableImplicitFrameworkReferences>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <Version>2.7.1</Version>
+    <Version>2.8.0</Version>
 
     <Description>NLog TableStorageTarget for writing to Azure Table Storage OR Azure CosmosDB Tables</Description>
     <Authors>jdetmar</Authors>
@@ -19,7 +19,7 @@
     <RepositoryUrl>https://github.com/JDetmar/NLog.Extensions.AzureStorage.git</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>
-Fixed bug where LogManager.Flush() or LogManager.Shutdown() completed prematurely when using BatchSize &gt; 100
+Support override of LogTimeStamp using first &lt;contextproperty&gt;
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/NLog.Extensions.AzureCosmosTable/README.md
+++ b/src/NLog.Extensions.AzureCosmosTable/README.md
@@ -70,7 +70,8 @@ Instead of using the predefined NLogEntity-properties, then one can specify want
 </targets>
 ```
 
-It will by default always include the hardcoded property `LogTimeStamp` of type DateTime.
+It will by default include the hardcoded property `LogTimeStamp` of type DateTime that contains `LogEventInfo.TimeStamp.ToUniversalTime()`.
+ - This can be overriden by having `<contextproperty name="LogTimeStamp">` as the first property, where empty property-value means leave out.
 
 ### Batching Policy
 


### PR DESCRIPTION
Resolves #97 by supporting this:

```xml
	<target xsi:type="AzureCosmosTable"
		name="cosmostable"
		connectionString="xxxxxxxx"
		tableName="xxxx"
		layout="JSON"
		partitionKey ="${date:format=yyyy-MM-dd}">
	   <contextproperty name="LogTimeStamp" layout="${date:format=O}" />
	   <contextproperty name="message" layout="${message}" />
	</target>
```