### PR TITLE
AzureServiceBus - Updated to Microsoft.Azure.ServiceBus ver. 5.1.2

### DIFF
--- a/src/NLog.Extensions.AzureBlobStorage/README.md
+++ b/src/NLog.Extensions.AzureBlobStorage/README.md
@@ -39,7 +39,7 @@ _contentType_ - Azure blob ContentType (Default = text/plain)
 
 _connectionString_ - Azure storage connection string. Ex. `UseDevelopmentStorage=true;`
 
-_serviceUri_ - Alternative to ConnectionString, where Managed Identiy is applied from AzureServiceTokenProvider.
+_serviceUri_ - Alternative to ConnectionString, where Managed Identiy is acquired from AzureServiceTokenProvider for User delegation SAS.
 
 _tenantIdentity_ - Alternative to ConnectionString. Used together with ServiceUri. Input for AzureServiceTokenProvider.
 

--- a/src/NLog.Extensions.AzureQueueStorage/README.md
+++ b/src/NLog.Extensions.AzureQueueStorage/README.md
@@ -33,7 +33,7 @@ _queueName_ - QueueName. [Layout](https://github.com/NLog/NLog/wiki/Layouts)
 
 _connectionString_ - Azure storage connection string. Ex. `UseDevelopmentStorage=true;`
 
-_serviceUri_ - Alternative to ConnectionString, where Managed Identiy is applied from AzureServiceTokenProvider.
+_serviceUri_ - Alternative to ConnectionString, where Managed Identiy is acquired from AzureServiceTokenProvider for User delegation SAS.
 
 _tenantIdentity_ - Alternative to ConnectionString. Used together with ServiceUri. Input for AzureServiceTokenProvider.
 

--- a/src/NLog.Extensions.AzureServiceBus/NLog.Extensions.AzureServiceBus.csproj
+++ b/src/NLog.Extensions.AzureServiceBus/NLog.Extensions.AzureServiceBus.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
 
     <Description>NLog ServiceBusTarget for writing to Azure Service Bus Topic or Queue</Description>
     <Authors>jdetmar</Authors>
@@ -18,7 +18,7 @@
     <RepositoryUrl>https://github.com/JDetmar/NLog.Extensions.AzureStorage.git</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>
-Added support for TimeToLiveSeconds and TimeToLiveDays for messages
+Updated to Microsoft.Azure.ServiceBus ver. 5.1.2 (Bug fixes)
     </PackageReleaseNotes>
   </PropertyGroup>
 
@@ -29,7 +29,7 @@ Added support for TimeToLiveSeconds and TimeToLiveDays for messages
 
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.6.8" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Guess last version-bump before changing to `Azure.Messaging.ServiceBus`:

https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md