### PR TITLE
Fix DataTable error: It raise error when the table already exists.

### DIFF
--- a/src/NLog.Extensions.AzureDataTables/DataTablesTarget.cs
+++ b/src/NLog.Extensions.AzureDataTables/DataTablesTarget.cs
@@ -430,7 +430,7 @@ namespace NLog.Targets
                     
                     var table = _client.GetTableClient(tableName);
                     
-                    if (tableExists.Value != null)
+                    if (tableExists != null)
                         InternalLogger.Debug("AzureDataTablesTarget: Created new table: {0}", tableName);
                     else
                         InternalLogger.Debug("AzureDataTablesTarget: Opened existing table: {0}", tableName);


### PR DESCRIPTION
When the table exist it raise error

```
2021-10-14 16:41:53.1195 Error AzureDataTablesTarget: Failed to initialize table=MyName Exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at NLog.Targets.DataTablesTarget.CloudTableService.InitializeAndCacheTableAsync(String tableName, CancellationToken cancellationToken)
```