### PR TITLE
Add support for user assigned managed identity

### DIFF
--- a/src/NLog.Extensions.AzureEventHub/IEventHubService.cs
+++ b/src/NLog.Extensions.AzureEventHub/IEventHubService.cs
@@ -8,7 +8,7 @@ namespace NLog.Extensions.AzureStorage
     internal interface IEventHubService
     {
         string EventHubName { get; }
-        void Connect(string connectionString, string eventHubName, string serviceUri, string tenantIdentity, string resourceIdentity);
+        void Connect(string connectionString, string eventHubName, string serviceUri, string tenantIdentity, string clientIdentity, string resourceIdentity);
         Task CloseAsync();
         Task SendAsync(IEnumerable<EventData> eventDataBatch, string partitionKey, CancellationToken cancellationToken);
     }

--- a/src/NLog.Extensions.AzureEventHub/NLog.Extensions.AzureEventHub.csproj
+++ b/src/NLog.Extensions.AzureEventHub/NLog.Extensions.AzureEventHub.csproj
@@ -32,6 +32,7 @@ Docs: https://github.com/JDetmar/NLog.Extensions.AzureStorage/blob/master/src/NL
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.5.0" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.6.2" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />
     <PackageReference Include="NLog" Version="4.6.8" />

--- a/test/NLog.Extensions.AzureEventHub.Tests/EventHubServiceMock.cs
+++ b/test/NLog.Extensions.AzureEventHub.Tests/EventHubServiceMock.cs
@@ -23,7 +23,7 @@ namespace NLog.Extensions.AzureEventHub.Test
                 EventDataSent.Clear();
         }
 
-        public void Connect(string connectionString, string eventHubName, string serviceUri, string tenantIdentity, string resourceIdentity)
+        public void Connect(string connectionString, string eventHubName, string serviceUri, string tenantIdentity, string clientIdentity, string resourceIdentity)
         {
             ConnectionString = connectionString;
             EventHubName = eventHubName;


### PR DESCRIPTION
I needed to use this package to access an event hub with a user assigned managed identity on Azure. I couldn't get it to work with the existing parameters so I modified it to support a clientIdentity parameter. This is used to access the managed identity. I figured I would send this modification upstream in case anyone else out there needs this.