### PR TITLE
Fixed handling of ResourceIdentity for AzureServiceTokenProviderCredentials

### DIFF
--- a/src/NLog.Extensions.AzureBlobStorage/BlobStorageTarget.cs
+++ b/src/NLog.Extensions.AzureBlobStorage/BlobStorageTarget.cs
@@ -142,7 +142,7 @@ namespace NLog.Targets
                 }
 
                 _cloudBlobService.Connect(connectionString, serviceUri, tenantIdentity, resourceIdentity, clientIdentity, blobMetadata, blobTags);
-                InternalLogger.Trace("AzureBlobStorageTarget - Initialized");
+                InternalLogger.Debug("AzureBlobStorageTarget - Initialized");
             }
             catch (Exception ex)
             {
@@ -356,7 +356,7 @@ namespace NLog.Targets
 
                 public AzureServiceTokenProviderCredentials(string tenantIdentity, string resourceIdentity, string clientIdentity)
                 {
-                    if (string.IsNullOrWhiteSpace(_resourceIdentity))
+                    if (string.IsNullOrWhiteSpace(resourceIdentity))
                         _resourceIdentity = "https://storage.azure.com/";
                     else
                         _resourceIdentity = resourceIdentity;

--- a/src/NLog.Extensions.AzureDataTables/DataTablesTarget.cs
+++ b/src/NLog.Extensions.AzureDataTables/DataTablesTarget.cs
@@ -158,7 +158,7 @@ namespace NLog.Targets
                 }
 
                 _cloudTableService.Connect(connectionString, serviceUri, tenantIdentity, resourceIdentity, clientIdentity, accountName, accessKey);
-                InternalLogger.Trace("AzureDataTablesTarget(Name={0}): Initialized", Name);
+                InternalLogger.Debug("AzureDataTablesTarget(Name={0}): Initialized", Name);
             }
             catch (Exception ex)
             {
@@ -363,7 +363,7 @@ namespace NLog.Targets
 
                 public AzureServiceTokenProviderCredentials(string tenantIdentity, string resourceIdentity, string clientIdentity)
                 {
-                    if (string.IsNullOrWhiteSpace(_resourceIdentity))
+                    if (string.IsNullOrWhiteSpace(resourceIdentity))
                         _resourceIdentity = "https://database.windows.net/";
                     else
                         _resourceIdentity = resourceIdentity;

--- a/src/NLog.Extensions.AzureEventHub/EventHubTarget.cs
+++ b/src/NLog.Extensions.AzureEventHub/EventHubTarget.cs
@@ -152,10 +152,11 @@ namespace NLog.Targets
                 }
 
                 _eventHubService.Connect(connectionString, eventHubName, serviceUri, tenantIdentity, resourceIdentity, clientIdentity);
+                InternalLogger.Debug("AzureEventHubTarget(Name={0}): Initialized", Name);
             }
             catch (Exception ex)
             {
-                InternalLogger.Error(ex, "AzureEventHub(Name={0}): Failed to create EventHubClient with connectionString={1} to EventHubName={2}.", Name, connectionString, eventHubName);
+                InternalLogger.Error(ex, "AzureEventHubTarget(Name={0}): Failed to create EventHubClient with connectionString={1} to EventHubName={2}.", Name, connectionString, eventHubName);
                 throw;
             }
         }
@@ -188,7 +189,7 @@ namespace NLog.Targets
                 }
                 catch (Exception ex)
                 {
-                    InternalLogger.Error(ex, "AzureEventHub(Name={0}): Failed writing {1} logevents to EntityPath={2} with PartitionKey={3}", Name, 1, _eventHubService?.EventHubName, partitionKey);
+                    InternalLogger.Error(ex, "AzureEventHubTarget(Name={0}): Failed writing {1} logevents to EntityPath={2} with PartitionKey={3}", Name, 1, _eventHubService?.EventHubName, partitionKey);
                     throw;
                 }
             }
@@ -212,7 +213,7 @@ namespace NLog.Targets
                 }
                 catch (Exception ex)
                 {
-                    InternalLogger.Error(ex, "AzureEventHub(Name={0}): Failed writing {1} logevents to EntityPath={2} with PartitionKey={3}", Name, bucketCount, _eventHubService?.EventHubName, partitionKey);
+                    InternalLogger.Error(ex, "AzureEventHubTarget(Name={0}): Failed writing {1} logevents to EntityPath={2} with PartitionKey={3}", Name, bucketCount, _eventHubService?.EventHubName, partitionKey);
                     if (multipleTasks == null)
                         throw;
                 }
@@ -249,7 +250,7 @@ namespace NLog.Targets
                     if (ex.Reason != EventHubsException.FailureReason.MessageSizeExceeded && ex.Reason != EventHubsException.FailureReason.QuotaExceeded)
                         throw;
 
-                    InternalLogger.Error(ex, "AzureEventHub(Name={0}): Skipping failing logevents for EntityPath={2} with PartitionKey={3}", Name, ex.EventHubName, partitionKey);
+                    InternalLogger.Error(ex, "AzureEventHubTarget(Name={0}): Skipping failing logevents for EntityPath={2} with PartitionKey={3}", Name, ex.EventHubName, partitionKey);
                 }
             }
         }
@@ -379,7 +380,7 @@ namespace NLog.Targets
             }
             catch (Exception ex)
             {
-                InternalLogger.Error(ex, "AzureEventHub(Name={0}): Failed to convert to EventData.", Name);
+                InternalLogger.Error(ex, "AzureEventHubTarget(Name={0}): Failed to convert to EventData.", Name);
 
                 if (allowThrow || LogManager.ThrowExceptions)
                     throw;
@@ -407,7 +408,7 @@ namespace NLog.Targets
             }
             catch (Exception ex)
             {
-                InternalLogger.Error(ex, "AzureEventHub(Name={0}): Failed converting {1} value to EventData.", Name, value?.GetType());
+                InternalLogger.Error(ex, "AzureEventHubTarget(Name={0}): Failed converting {1} value to EventData.", Name, value?.GetType());
                 return null;
             }
         }
@@ -443,7 +444,7 @@ namespace NLog.Targets
 
                 public AzureServiceTokenProviderCredentials(string tenantIdentity, string resourceIdentity, string clientIdentity)
                 {
-                    if (string.IsNullOrWhiteSpace(_resourceIdentity))
+                    if (string.IsNullOrWhiteSpace(resourceIdentity))
                         _resourceIdentity = "https://eventhubs.azure.net/";
                     else
                         _resourceIdentity = resourceIdentity;
@@ -465,7 +466,7 @@ namespace NLog.Targets
                     }
                     catch (Exception ex)
                     {
-                        InternalLogger.Error(ex, "AzureEventHub - Failed getting AccessToken from AzureServiceTokenProvider for resource {0}", _resourceIdentity);
+                        InternalLogger.Error(ex, "AzureEventHubTarget - Failed getting AccessToken from AzureServiceTokenProvider for resource {0}", _resourceIdentity);
                         throw;
                     }
                 }

--- a/src/NLog.Extensions.AzureQueueStorage/QueueStorageTarget.cs
+++ b/src/NLog.Extensions.AzureQueueStorage/QueueStorageTarget.cs
@@ -130,7 +130,7 @@ namespace NLog.Targets
                 }
 
                 _cloudQueueService.Connect(connectionString, serviceUri, tenantIdentity, resourceIdentity, clientIdentity, timeToLive, queueMetadata);
-                InternalLogger.Trace("AzureQueueStorageTarget - Initialized");
+                InternalLogger.Debug("AzureQueueStorageTarget - Initialized");
             }
             catch (Exception ex)
             {
@@ -235,7 +235,7 @@ namespace NLog.Targets
 
                 public AzureServiceTokenProviderCredentials(string tenantIdentity, string resourceIdentity, string clientIdentity)
                 {
-                    if (string.IsNullOrWhiteSpace(_resourceIdentity))
+                    if (string.IsNullOrWhiteSpace(resourceIdentity))
                         _resourceIdentity = "https://storage.azure.com/";
                     else
                         _resourceIdentity = resourceIdentity;

--- a/src/NLog.Extensions.AzureServiceBus/ServiceBusTarget.cs
+++ b/src/NLog.Extensions.AzureServiceBus/ServiceBusTarget.cs
@@ -188,11 +188,11 @@ namespace NLog.Targets
                 }
 
                 _cloudServiceBus.Connect(connectionString, queueOrTopicName, serviceUri, tenantIdentity, resourceIdentity, clientIdentity, timeToLive);
-                InternalLogger.Trace("AzureServiceBus - Initialized");
+                InternalLogger.Debug("AzureServiceBusTarget(Name={0}): Initialized", Name);
             }
             catch (Exception ex)
             {
-                InternalLogger.Error(ex, "AzureServiceBus(Name={0}): Failed to create ServiceBusClient with connectionString={1} and EntityPath={2}.", Name, connectionString, queueOrTopicName);
+                InternalLogger.Error(ex, "AzureServiceBusTarget(Name={0}): Failed to create ServiceBusClient with connectionString={1} and EntityPath={2}.", Name, connectionString, queueOrTopicName);
                 throw;
             }
         }
@@ -213,7 +213,7 @@ namespace NLog.Targets
                     }
                     else
                     {
-                        InternalLogger.Error("AzureServiceBus(Name={0}): Failed to parse TimeToLiveSeconds={1}", Name, timeToLiveSeconds);
+                        InternalLogger.Error("AzureServiceBusTarget(Name={0}): Failed to parse TimeToLiveSeconds={1}", Name, timeToLiveSeconds);
                     }
                 }
                 else
@@ -227,14 +227,14 @@ namespace NLog.Targets
                         }
                         else
                         {
-                            InternalLogger.Error("AzureServiceBus(Name={0}): Failed to parse TimeToLiveDays={1}", Name, timeToLiveDays);
+                            InternalLogger.Error("AzureServiceBusTarget(Name={0}): Failed to parse TimeToLiveDays={1}", Name, timeToLiveDays);
                         }
                     }
                 }
             }
             catch (Exception ex)
             {
-                InternalLogger.Error(ex, "AzureServiceBus(Name={0}): Failed to parse TimeToLive value. Seconds={1}, Days={2}", Name, timeToLiveSeconds, timeToLiveDays);
+                InternalLogger.Error(ex, "AzureServiceBusTarget(Name={0}): Failed to parse TimeToLive value. Seconds={1}, Days={2}", Name, timeToLiveSeconds, timeToLiveDays);
             }
 
             return default(TimeSpan?);
@@ -271,7 +271,7 @@ namespace NLog.Targets
                 }
                 catch (Exception ex)
                 {
-                    InternalLogger.Error(ex, "AzureServiceBus(Name={0}): Failed writing {1} logevents to EntityPath={2} with PartitionKey={3}", Name, 1, _cloudServiceBus?.EntityPath, partitionKey);
+                    InternalLogger.Error(ex, "AzureServiceBusTarget(Name={0}): Failed writing {1} logevents to EntityPath={2} with PartitionKey={3}", Name, 1, _cloudServiceBus?.EntityPath, partitionKey);
                     throw;
                 }
             }
@@ -295,7 +295,7 @@ namespace NLog.Targets
                 }
                 catch (Exception ex)
                 {
-                    InternalLogger.Error(ex, "AzureServiceBus(Name={0}): Failed writing {1} logevents to EntityPath={2} with PartitionKey={3}", Name, bucketCount, _cloudServiceBus?.EntityPath, partitionKey);
+                    InternalLogger.Error(ex, "AzureServiceBusTarget(Name={0}): Failed writing {1} logevents to EntityPath={2} with PartitionKey={3}", Name, bucketCount, _cloudServiceBus?.EntityPath, partitionKey);
                     if (multipleTasks == null)
                         throw;
                 }
@@ -332,7 +332,7 @@ namespace NLog.Targets
                     if (ex.Reason != ServiceBusFailureReason.MessageSizeExceeded && ex.Reason != ServiceBusFailureReason.QuotaExceeded)
                         throw;
 
-                    InternalLogger.Error(ex, "AzureServiceBus(Name={0}): Skipping failing logevents for EntityPath={2}", Name, ex.EntityPath);
+                    InternalLogger.Error(ex, "AzureServiceBusTarget(Name={0}): Skipping failing logevents for EntityPath={2}", Name, ex.EntityPath);
                 }
             }
         }
@@ -479,7 +479,7 @@ namespace NLog.Targets
             }
             catch (Exception ex)
             {
-                InternalLogger.Error(ex, "AzureServiceBus(Name={0}): Failed to convert to Message.", Name);
+                InternalLogger.Error(ex, "AzureServiceBusTarget(Name={0}): Failed to convert to Message.", Name);
 
                 if (allowThrow || LogManager.ThrowExceptions)
                     throw;
@@ -507,7 +507,7 @@ namespace NLog.Targets
             }
             catch (Exception ex)
             {
-                InternalLogger.Error(ex, "AzureServiceBus(Name={0}): Failed converting {1} value to Message.", Name, value?.GetType());
+                InternalLogger.Error(ex, "AzureServiceBusTarget(Name={0}): Failed converting {1} value to Message.", Name, value?.GetType());
                 return null;
             }
         }
@@ -545,7 +545,7 @@ namespace NLog.Targets
 
                 public AzureServiceTokenProviderCredentials(string tenantIdentity, string resourceIdentity, string clientIdentity)
                 {
-                    if (string.IsNullOrWhiteSpace(_resourceIdentity))
+                    if (string.IsNullOrWhiteSpace(resourceIdentity))
                         _resourceIdentity = "https://servicebus.azure.net/";
                     else
                         _resourceIdentity = resourceIdentity;
@@ -567,7 +567,7 @@ namespace NLog.Targets
                     }
                     catch (Exception ex)
                     {
-                        InternalLogger.Error(ex, "AzureServiceBus - Failed getting AccessToken from AzureServiceTokenProvider for resource {0}", _resourceIdentity);
+                        InternalLogger.Error(ex, "AzureServiceBusTarget - Failed getting AccessToken from AzureServiceTokenProvider for resource {0}", _resourceIdentity);
                         throw;
                     }
                 }

--- a/test/NLog.Extensions.AzureAccessToken.Tests/NLog.Extensions.AzureAccessToken.Tests.csproj
+++ b/test/NLog.Extensions.AzureAccessToken.Tests/NLog.Extensions.AzureAccessToken.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/test/NLog.Extensions.AzureBlobStorage.Tests/NLog.Extensions.AzureBlobStorage.Tests.csproj
+++ b/test/NLog.Extensions.AzureBlobStorage.Tests/NLog.Extensions.AzureBlobStorage.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/test/NLog.Extensions.AzureDataTables.Tests/NLog.Extensions.AzureDataTables.Tests.csproj
+++ b/test/NLog.Extensions.AzureDataTables.Tests/NLog.Extensions.AzureDataTables.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/test/NLog.Extensions.AzureEventHub.Tests/NLog.Extensions.AzureEventHub.Tests.csproj
+++ b/test/NLog.Extensions.AzureEventHub.Tests/NLog.Extensions.AzureEventHub.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/test/NLog.Extensions.AzureQueueStorage.Tests/NLog.Extensions.AzureQueueStorage.Tests.csproj
+++ b/test/NLog.Extensions.AzureQueueStorage.Tests/NLog.Extensions.AzureQueueStorage.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/test/NLog.Extensions.AzureServiceBus.Tests/NLog.Extensions.AzureServiceBus.Tests.csproj
+++ b/test/NLog.Extensions.AzureServiceBus.Tests/NLog.Extensions.AzureServiceBus.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
Changed from incorrect:
```
if (string.IsNullOrWhiteSpace(_resourceIdentity))
```
To
```
if (string.IsNullOrWhiteSpace(resourceIdentity))
```