### PR TITLE
Added ServiceUrl-property to make transition easier for new users

### DIFF
--- a/src/NLog.Extensions.AzureBlobStorage/BlobStorageTarget.cs
+++ b/src/NLog.Extensions.AzureBlobStorage/BlobStorageTarget.cs
@@ -34,6 +34,10 @@ namespace NLog.Targets
         /// </summary>
         public Layout ServiceUri { get; set; }
 
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [Obsolete("Instead use ServiceUri")]
+        public Layout ServiceUrl { get => ServiceUri; set => ServiceUri = value; }
+
         /// <summary>
         /// Alternative to ConnectionString, when using <see cref="ServiceUri"/>
         /// </summary>
@@ -66,6 +70,10 @@ namespace NLog.Targets
 
         [RequiredParameter]
         public Layout Container { get; set; }
+
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [Obsolete("Instead use Container")]
+        public Layout ContainerName { get => Container; set => Container = value; }
 
         [RequiredParameter]
         public Layout BlobName { get; set; }

--- a/src/NLog.Extensions.AzureDataTables/DataTablesTarget.cs
+++ b/src/NLog.Extensions.AzureDataTables/DataTablesTarget.cs
@@ -64,6 +64,10 @@ namespace NLog.Targets
         /// </remarks>
         public Layout ServiceUri { get; set; }
 
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [Obsolete("Instead use ServiceUri")]
+        public Layout ServiceUrl { get => ServiceUri; set => ServiceUri = value; }
+
         /// <summary>
         /// Alternative to ConnectionString, when using <see cref="ServiceUri"/>
         /// </summary>

--- a/src/NLog.Extensions.AzureEventHub/EventHubTarget.cs
+++ b/src/NLog.Extensions.AzureEventHub/EventHubTarget.cs
@@ -86,6 +86,10 @@ namespace NLog.Targets
         /// </summary>
         public Layout ServiceUri { get; set; }
 
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [Obsolete("Instead use ServiceUri")]
+        public Layout ServiceUrl { get => ServiceUri; set => ServiceUri = value; }
+
         /// <summary>
         /// Alternative to ConnectionString, when using <see cref="ServiceUri"/>
         /// </summary>

--- a/src/NLog.Extensions.AzureQueueStorage/QueueStorageTarget.cs
+++ b/src/NLog.Extensions.AzureQueueStorage/QueueStorageTarget.cs
@@ -30,6 +30,10 @@ namespace NLog.Targets
         /// </summary>
         public Layout ServiceUri { get; set; }
 
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [Obsolete("Instead use ServiceUri")]
+        public Layout ServiceUrl { get => ServiceUri; set => ServiceUri = value; }
+
         /// <summary>
         /// Alternative to ConnectionString, when using <see cref="ServiceUri"/>
         /// </summary>

--- a/src/NLog.Extensions.AzureServiceBus/NLog.Extensions.AzureServiceBus.csproj
+++ b/src/NLog.Extensions.AzureServiceBus/NLog.Extensions.AzureServiceBus.csproj
@@ -36,7 +36,7 @@ Docs: https://github.com/JDetmar/NLog.Extensions.AzureStorage/blob/master/src/NL
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.16.1" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.16.2" />
     <PackageReference Include="Azure.Identity" Version="1.10.3" />
     <PackageReference Include="NLog" Version="4.7.15" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/src/NLog.Extensions.AzureServiceBus/ServiceBusTarget.cs
+++ b/src/NLog.Extensions.AzureServiceBus/ServiceBusTarget.cs
@@ -107,6 +107,10 @@ namespace NLog.Targets
         /// </summary>
         public Layout ServiceUri { get; set; }
 
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [Obsolete("Instead use ServiceUri")]
+        public Layout ServiceUrl { get => ServiceUri; set => ServiceUri = value; }
+
         /// <summary>
         /// Alternative to ConnectionString, when using <see cref="ServiceUri"/>
         /// </summary>


### PR DESCRIPTION
One might consider if `ContainerName` should be the official setting, and `Container` is the obsolete one.