### PR TITLE
BlobStorageTarget - Rename config properties to align with Microsoft naming convention

### DIFF
--- a/src/NLog.Extensions.AzureBlobStorage/BlobStorageTarget.cs
+++ b/src/NLog.Extensions.AzureBlobStorage/BlobStorageTarget.cs
@@ -30,7 +30,8 @@ namespace NLog.Targets
         public Layout ConnectionString { get; set; }
 
         /// <summary>
-        /// Alternative to ConnectionString
+        /// Uri to reference the blob service (e.g. https://{account_name}.blob.core.windows.net). 
+        /// Input for <see cref="BlobServiceClient"/>. Required, when <see cref="ConnectionString"/> is not configured. Overrides <see cref="ConnectionString"/> when both are set.
         /// </summary>
         public Layout ServiceUri { get; set; }
 
@@ -40,6 +41,7 @@ namespace NLog.Targets
 
         /// <summary>
         /// Alternative to ConnectionString, when using <see cref="ServiceUri"/>
+        /// tenantId for <see cref="Azure.Identity.DefaultAzureCredentialOptions"/> and <see cref="Azure.Identity.ClientSecretCredential"/>. Requires <see cref="ServiceUri"/>.
         /// </summary>
         public Layout TenantIdentity { get; set; }
 
@@ -48,7 +50,7 @@ namespace NLog.Targets
         public Layout ResourceIdentity { get => ManagedIdentityResourceId; set => ManagedIdentityResourceId = value; }
 
         /// <summary>
-        /// resourceId for <see cref="Azure.Identity.DefaultAzureCredentialOptions.ManagedIdentityResourceId"/> on <see cref="Azure.Identity.DefaultAzureCredentialOptions"/>.
+        /// resourceId for <see cref="Azure.Identity.DefaultAzureCredentialOptions.ManagedIdentityResourceId"/> on <see cref="Azure.Identity.DefaultAzureCredentialOptions"/>. Requires <see cref="ServiceUri"/> .
         /// </summary>
         public Layout ManagedIdentityResourceId { get; set; }
 
@@ -57,7 +59,7 @@ namespace NLog.Targets
         public Layout ClientIdentity { get => ManagedIdentityClientId; set => ManagedIdentityClientId = value; }
 
         /// <summary>
-        /// Sets <see cref="Azure.Identity.DefaultAzureCredentialOptions.ManagedIdentityClientId"/> on <see cref="Azure.Identity.DefaultAzureCredentialOptions"/>.
+        /// Sets <see cref="Azure.Identity.DefaultAzureCredentialOptions.ManagedIdentityClientId"/> on <see cref="Azure.Identity.DefaultAzureCredentialOptions"/>. Requires <see cref="ServiceUri"/>.
         /// </summary>
         public Layout ManagedIdentityClientId { get; set; }
 
@@ -77,12 +79,12 @@ namespace NLog.Targets
         public Layout AccessKey { get; set; }
 
         /// <summary>
-        /// clientId for <see cref="Azure.Identity.ClientSecretCredential"/> authentication. Requires <see cref="TenantIdentity"/> and <see cref="ClientAuthSecret"/>.
+        /// clientId for <see cref="Azure.Identity.ClientSecretCredential"/> authentication. Requires <see cref="ServiceUri"/>, <see cref="TenantIdentity"/> and <see cref="ClientAuthSecret"/>.
         /// </summary>
         public Layout ClientAuthId { get; set; }
 
         /// <summary>
-        /// clientSecret for <see cref="Azure.Identity.ClientSecretCredential"/> authentication. Requires <see cref="TenantIdentity"/> and <see cref="ClientAuthId"/>.
+        /// clientSecret for <see cref="Azure.Identity.ClientSecretCredential"/> authentication. Requires <see cref="ServiceUri"/>, <see cref="TenantIdentity"/> and <see cref="ClientAuthId"/>.
         /// </summary>
         public Layout ClientAuthSecret { get; set; }
 

--- a/src/NLog.Extensions.AzureBlobStorage/ICloudBlobService.cs
+++ b/src/NLog.Extensions.AzureBlobStorage/ICloudBlobService.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,7 +6,7 @@ namespace NLog.Extensions.AzureStorage
 {
     interface ICloudBlobService
     {
-        void Connect(string connectionString, string serviceUri, string tenantIdentity, string resourceIdentifier, string clientIdentity, string sharedAccessSignature, string storageAccountName, string storageAccountAccessKey, string clientId, string clientSecret, IDictionary<string, string> blobMetadata, IDictionary<string, string> blobTags);
+        void Connect(string connectionString, string serviceUri, string tenantIdentity, string managedIdentityResourceId, string managedIdentityClientId, string sharedAccessSignature, string storageAccountName, string storageAccountAccessKey, string clientAuthId, string clientAuthSecret, IDictionary<string, string> blobMetadata, IDictionary<string, string> blobTags);
         Task AppendFromByteArrayAsync(string containerName, string blobName, string contentType, byte[] buffer, CancellationToken cancellationToken);
     }
 }

--- a/src/NLog.Extensions.AzureBlobStorage/README.md
+++ b/src/NLog.Extensions.AzureBlobStorage/README.md
@@ -39,23 +39,23 @@ _contentType_ - Azure blob ContentType (Default = text/plain)
 
 _connectionString_ - Azure storage connection string. Ex. `UseDevelopmentStorage=true;`
 
-_serviceUri_ - Alternative to ConnectionString, where Managed Identiy is acquired from DefaultAzureCredential.
+_serviceUri_ - Uri to reference the blob service (e.g. https://{account_name}.blob.core.windows.net). Input for `BlobServiceClient`. Required, when `connectionString` is not configured. Ovverrides `connectionString` when both are set.
 
-_clientIdentity_ - Alternative to ConnectionString. Used together with ServiceUri. Input for DefaultAzureCredential as ManagedIdentityClientId.
+_managedIdentityClientId_ - Sets `ManagedIdentityClientId` on `DefaultAzureCredentialOptions`
 
-_resourceIdentity_ - Alternative to ConnectionString. Used together with ServiceUri. Input for DefaultAzureCredential as ManagedIdentityResourceId.
+_managedIdentityResourceId_ - resourceId for `ManagedIdentityResourceId` on `DefaultAzureCredentialOptions`.
 
-_tenantIdentity_ - Alternative to ConnectionString. Used together with ServiceUri. Input for DefaultAzureCredential / ClientSecretCredential.
+_tenantIdentity_ - tenantId for `DefaultAzureCredentialOptions` and `ClientSecretCredential`.
 
-_sharedAccessSignature_ - Alternative to ConnectionString. Used together with ServiceUri. Input for AzureSasCredential
+_sharedAccessSignature_ - Access signature for `AzureSasCredential` authentication. Requires `serviceUri`.
 
-_accountName_ - Alternative to ConnectionString. Used together with ServiceUri. Input for StorageSharedKeyCredential-AccountName
+_accountName_ - accountName for `StorageSharedKeyCredential` authentication. Requires `serviceUri` and `accessKey`.
 
-_accessKey_ - Alternative to ConnectionString. Used together with ServiceUri. Input for StorageSharedKeyCredential-AccessKey
+_accessKey_ - accountKey for `StorageSharedKeyCredential` authentication. Requires `serviceUri` and `accountName`.
 
-_clientId_ - Alternative to ConnectionString. Instantiates the `BlobServiceClient` using a `ClientSecretCredential` for authentication. Requires `TenantIdentity` and `ClientSecret`.
+_clientAuthId_ - clientId for `ClientSecretCredential` authentication. Requires `tenantIdentity` and `clientAuthSecret`.
 
-_clientSecret_ - Secret when using ClientId. Instantiates the `BlobServiceClient` using a `ClientSecretCredential` for authentication. Requires `TenantIdentity` and `ClientId`.
+_clientAuthSecret_ - clientSecret for `ClientSecretCredential` authentication. Requires `tenantIdentity` and `clientAuthId`.
 
 ### Batching Policy
 
@@ -135,4 +135,16 @@ NLog Layout makes it possible to retrieve settings from [many locations](https:/
 
 ```c#
   NLog.GlobalDiagnosticsContext.Set("AzureBlobConnectionString", "UseDevelopmentStorage=true;");
+```
+
+#### Simple configurations
+
+* Using `DefaultAzureCredential` on a given storage account appsettings.json on .NetCore:
+
+```json
+  {
+    "ConnectionStrings": {
+      "AzureBlob": "UseDevelopmentStorage=true;"
+    }
+  }
 ```

--- a/src/NLog.Extensions.AzureBlobStorage/README.md
+++ b/src/NLog.Extensions.AzureBlobStorage/README.md
@@ -39,13 +39,13 @@ _contentType_ - Azure blob ContentType (Default = text/plain)
 
 _connectionString_ - Azure storage connection string. Ex. `UseDevelopmentStorage=true;`
 
-_serviceUri_ - Uri to reference the blob service (e.g. https://{account_name}.blob.core.windows.net). Input for `BlobServiceClient`. Required, when `connectionString` is not configured. Ovverrides `connectionString` when both are set.
+_serviceUri_ - Uri to reference the blob service (e.g. https://{account_name}.blob.core.windows.net). Input for `BlobServiceClient`. Required, when `connectionString` is not configured. Overrides `connectionString` when both are set.
 
-_managedIdentityClientId_ - Sets `ManagedIdentityClientId` on `DefaultAzureCredentialOptions`
+_managedIdentityClientId_ - Sets `ManagedIdentityClientId` on `DefaultAzureCredentialOptions`. Requires `serviceUri`
 
-_managedIdentityResourceId_ - resourceId for `ManagedIdentityResourceId` on `DefaultAzureCredentialOptions`.
+_managedIdentityResourceId_ - resourceId for `ManagedIdentityResourceId` on `DefaultAzureCredentialOptions`. Requires `serviceUri`.
 
-_tenantIdentity_ - tenantId for `DefaultAzureCredentialOptions` and `ClientSecretCredential`.
+_tenantIdentity_ - tenantId for `DefaultAzureCredentialOptions` and `ClientSecretCredential`. Requires `serviceUri`.
 
 _sharedAccessSignature_ - Access signature for `AzureSasCredential` authentication. Requires `serviceUri`.
 
@@ -53,9 +53,9 @@ _accountName_ - accountName for `StorageSharedKeyCredential` authentication. Req
 
 _accessKey_ - accountKey for `StorageSharedKeyCredential` authentication. Requires `serviceUri` and `accountName`.
 
-_clientAuthId_ - clientId for `ClientSecretCredential` authentication. Requires `tenantIdentity` and `clientAuthSecret`.
+_clientAuthId_ - clientId for `ClientSecretCredential` authentication. Requires `serviceUri`, `tenantIdentity` and `clientAuthSecret`.
 
-_clientAuthSecret_ - clientSecret for `ClientSecretCredential` authentication. Requires `tenantIdentity` and `clientAuthId`.
+_clientAuthSecret_ - clientSecret for `ClientSecretCredential` authentication. Requires `serviceUri`,`tenantIdentity` and `clientAuthId`.
 
 ### Batching Policy
 
@@ -135,16 +135,4 @@ NLog Layout makes it possible to retrieve settings from [many locations](https:/
 
 ```c#
   NLog.GlobalDiagnosticsContext.Set("AzureBlobConnectionString", "UseDevelopmentStorage=true;");
-```
-
-#### Simple configurations
-
-* Using `DefaultAzureCredential` on a given storage account appsettings.json on .NetCore:
-
-```json
-  {
-    "ConnectionStrings": {
-      "AzureBlob": "UseDevelopmentStorage=true;"
-    }
-  }
 ```

--- a/src/NLog.Extensions.AzureStorage/AzureCredentialHelper.cs
+++ b/src/NLog.Extensions.AzureStorage/AzureCredentialHelper.cs
@@ -2,7 +2,7 @@ namespace NLog.Extensions.AzureStorage
 {
     internal static class AzureCredentialHelpers
     {
-        internal static Azure.Identity.DefaultAzureCredential CreateTokenCredentials(string clientIdentity, string tenantIdentity, string resourceIdentifier)
+        internal static Azure.Identity.DefaultAzureCredential CreateTokenCredentials(string managedIdentityClientId, string tenantIdentity, string managedIdentityResourceId)
         {
             var options = new Azure.Identity.DefaultAzureCredentialOptions();
 
@@ -11,16 +11,16 @@ namespace NLog.Extensions.AzureStorage
                 options.TenantId = tenantIdentity;
             }
 
-            if (!string.IsNullOrWhiteSpace(clientIdentity))
+            if (!string.IsNullOrWhiteSpace(managedIdentityClientId))
             {
-                options.ManagedIdentityClientId = clientIdentity;
-                options.WorkloadIdentityClientId = clientIdentity;
+                options.ManagedIdentityClientId = managedIdentityClientId;
+                options.WorkloadIdentityClientId = managedIdentityClientId;
             }
             else
             {
-                if (!string.IsNullOrWhiteSpace(resourceIdentifier))
+                if (!string.IsNullOrWhiteSpace(managedIdentityResourceId))
                 {
-                    options.ManagedIdentityResourceId = new Azure.Core.ResourceIdentifier(resourceIdentifier);
+                    options.ManagedIdentityResourceId = new Azure.Core.ResourceIdentifier(managedIdentityResourceId);
                 }
                 else if (string.IsNullOrWhiteSpace(tenantIdentity))
                 {

--- a/test/NLog.Extensions.AzureBlobStorage.Tests/CloudBlobServiceMock.cs
+++ b/test/NLog.Extensions.AzureBlobStorage.Tests/CloudBlobServiceMock.cs
@@ -17,7 +17,7 @@ namespace NLog.Extensions.AzureBlobStorage.Tests
 
         public IDictionary<string, string> BlobTags { get; private set; }
 
-        public void Connect(string connectionString, string serviceUri, string tenantIdentity, string resourceIdentifier, string clientIdentity, string sharedAccessSignature, string storageAccountName, string storageAccountAccessKey, string clientId, string clientSecret, IDictionary<string, string> blobMetadata, IDictionary<string, string> blobTags)
+        public void Connect(string connectionString, string serviceUri, string tenantIdentity, string managedIdentityResourceId, string managedIdentityClientId, string sharedAccessSignature, string storageAccountName, string storageAccountAccessKey, string clientAuthId, string clientAuthSecret, IDictionary<string, string> blobMetadata, IDictionary<string, string> blobTags)
         {
             ConnectionString = connectionString;
             BlobMetadata = blobMetadata;


### PR DESCRIPTION
Renamed the following properties
    ResourceIdentity => ManagedIdentityResourceId
    ClientIdentity => ManagedIdentityClientId
    ClientId => ClientAuthId
    ClientSecret => ClientAuthSecret

Adapted documentation accordingly