### PR TITLE
Fix CheckAndRepairTableNamingRules returning un-repaired table name

### DIFF
--- a/src/NLog.Extensions.AzureStorage/AzureStorageNameCache.cs
+++ b/src/NLog.Extensions.AzureStorage/AzureStorageNameCache.cs
@@ -118,7 +118,10 @@ namespace NLog.Extensions.AzureStorage
             if (simpleValidName?.Length >= 3)
                 return simpleValidName;
 
-            const string trimLeadingPattern = "^.*?(?=[a-zA-Z])";
+            // Strip a leading run of non-letters (e.g. digits). This trims whether or not a
+            // letter follows, so an all-digit input such as "123" collapses to empty and falls
+            // back to the default below (table names cannot begin with a numeric character).
+            const string trimLeadingPattern = "^[^a-zA-Z]+";
             const string trimFobiddenCharactersPattern = "[^a-zA-Z0-9]"; // Table names may contain only alphanumeric characters
 
             tableName = tableName ?? string.Empty;

--- a/src/NLog.Extensions.AzureStorage/AzureStorageNameCache.cs
+++ b/src/NLog.Extensions.AzureStorage/AzureStorageNameCache.cs
@@ -119,8 +119,9 @@ namespace NLog.Extensions.AzureStorage
                 return simpleValidName;
 
             const string trimLeadingPattern = "^.*?(?=[a-zA-Z])";
-            const string trimFobiddenCharactersPattern = "[^a-zA-Z0-9-]";
+            const string trimFobiddenCharactersPattern = "[^a-zA-Z0-9]"; // Table names may contain only alphanumeric characters
 
+            tableName = tableName ?? string.Empty;
             var pass1 = Regex.Replace(tableName, trimFobiddenCharactersPattern, String.Empty, RegexOptions.ExplicitCapture);
             var cleanedTableName = Regex.Replace(pass1, trimLeadingPattern, String.Empty, RegexOptions.ExplicitCapture);
             if (String.IsNullOrWhiteSpace(cleanedTableName) || cleanedTableName.Length > 63 || cleanedTableName.Length < 3)
@@ -128,7 +129,7 @@ namespace NLog.Extensions.AzureStorage
                 var tableDefault = "Logs";
                 return tableDefault;
             }
-            return tableName;
+            return cleanedTableName;
         }
     }
 }

--- a/test/NLog.Extensions.AzureDataTables.Tests/AzureStorageNameCacheTests.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/AzureStorageNameCacheTests.cs
@@ -1,0 +1,57 @@
+using NLog.Extensions.AzureStorage;
+using Xunit;
+
+namespace NLog.Extensions.AzureTableStorage.Tests
+{
+    public class AzureStorageNameCacheTests
+    {
+        // Azure table naming rules: alphanumeric only, may not begin with a digit,
+        // 3-63 chars, case-insensitive. The repair routine must RETURN a name that
+        // satisfies these rules, not the original invalid input.
+
+        [Theory]
+        [InlineData("MyValidTable", "MyValidTable")]   // already valid -> unchanged (fast path)
+        [InlineData("logs", "logs")]                    // already valid -> unchanged
+        public void CheckAndRepairTableNamingRules_ValidName_ReturnedUnchanged(string input, string expected)
+        {
+            Assert.Equal(expected, AzureStorageNameCache.CheckAndRepairTableNamingRules(input));
+        }
+
+        [Fact]
+        public void CheckAndRepairTableNamingRules_LeadingDigits_StripsLeadingDigits()
+        {
+            // "123logs" is invalid (begins with a digit). Repair should drop the
+            // leading digits and return "logs" -- NOT the original "123logs".
+            var result = AzureStorageNameCache.CheckAndRepairTableNamingRules("123logs");
+
+            Assert.Equal("logs", result);
+            Assert.False(char.IsDigit(result[0]), "repaired table name must not start with a digit");
+        }
+
+        [Fact]
+        public void CheckAndRepairTableNamingRules_ForbiddenCharacters_AreRemoved()
+        {
+            // Dashes/dots/etc are not allowed in table names (alphanumeric only).
+            var result = AzureStorageNameCache.CheckAndRepairTableNamingRules("my-table.name");
+
+            Assert.Equal("mytablename", result);
+            Assert.DoesNotContain('-', result);
+            Assert.DoesNotContain('.', result);
+        }
+
+        [Fact]
+        public void CheckAndRepairTableNamingRules_Unrepairable_FallsBackToDefault()
+        {
+            // Nothing usable -> documented "Logs" default.
+            Assert.Equal("Logs", AzureStorageNameCache.CheckAndRepairTableNamingRules("--"));
+        }
+
+        [Fact]
+        public void CheckAndRepairTableNamingRules_Null_DoesNotThrow()
+        {
+            // Defensive: a null rendered name must not throw (container path already guards this).
+            var result = AzureStorageNameCache.CheckAndRepairTableNamingRules(null);
+            Assert.Equal("Logs", result);
+        }
+    }
+}

--- a/test/NLog.Extensions.AzureDataTables.Tests/AzureStorageNameCacheTests.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/AzureStorageNameCacheTests.cs
@@ -29,6 +29,18 @@ namespace NLog.Extensions.AzureTableStorage.Tests
         }
 
         [Fact]
+        public void CheckAndRepairTableNamingRules_AllDigits_FallsBackToDefault()
+        {
+            // "123" contains no letters and table names cannot begin with a digit.
+            // After repair there is nothing usable, so it must fall back to the
+            // documented "Logs" default -- NOT return the original "123".
+            var result = AzureStorageNameCache.CheckAndRepairTableNamingRules("123");
+
+            Assert.Equal("Logs", result);
+            Assert.False(char.IsDigit(result[0]), "repaired table name must not start with a digit");
+        }
+
+        [Fact]
         public void CheckAndRepairTableNamingRules_ForbiddenCharacters_AreRemoved()
         {
             // Dashes/dots/etc are not allowed in table names (alphanumeric only).

--- a/test/NLog.Extensions.AzureDataTables.Tests/NLog.Extensions.AzureDataTables.Tests.csproj
+++ b/test/NLog.Extensions.AzureDataTables.Tests/NLog.Extensions.AzureDataTables.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/test/NLog.Extensions.AzureDataTables.Tests/TableNameRulesTests.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/TableNameRulesTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Net.Sockets;
+using Azure.Data.Tables;
+using Xunit;
+
+namespace NLog.Extensions.AzureTableStorage.Tests
+{
+    // Characterizes REAL Azure Table behavior (via Azurite) to confirm this is a genuine issue:
+    // a table name starting with a digit is genuinely rejected, so the repair returning the
+    // un-repaired "123logs" really would break table use.
+    public class TableNameRulesTests
+    {
+        private const string DevStorage = "UseDevelopmentStorage=true";
+
+        private static bool AzuriteTablesAvailable()
+        {
+            try
+            {
+                using var c = new TcpClient();
+                var r = c.BeginConnect("127.0.0.1", 10002, null, null);
+                return r.AsyncWaitHandle.WaitOne(TimeSpan.FromMilliseconds(500)) && c.Connected;
+            }
+            catch { return false; }
+        }
+
+        [Fact]
+        public void Azure_RejectsTableNameStartingWithDigit_ButAcceptsRepairedName()
+        {
+            if (!AzuriteTablesAvailable()) return;
+            var svc = new TableServiceClient(DevStorage);
+
+            // "123logs" is exactly what the buggy CheckAndRepairTableNamingRules returned.
+            var ex = Record.Exception(() => svc.CreateTableIfNotExists("123logs"));
+            Assert.NotNull(ex); // real Azure rejects a digit-leading table name
+
+            // "logs" is the repaired name -> must be usable.
+            var valid = "logs" + Guid.NewGuid().ToString("n").Substring(0, 8);
+            svc.CreateTableIfNotExists(valid);
+            svc.DeleteTable(valid);
+        }
+    }
+}

--- a/test/NLog.Extensions.AzureDataTables.Tests/TableNameRulesTests.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/TableNameRulesTests.cs
@@ -17,16 +17,18 @@ namespace NLog.Extensions.AzureTableStorage.Tests
             try
             {
                 using var c = new TcpClient();
-                var r = c.BeginConnect("127.0.0.1", 10002, null, null);
-                return r.AsyncWaitHandle.WaitOne(TimeSpan.FromMilliseconds(500)) && c.Connected;
+                // ConnectAsync + bounded Wait disposes the socket cleanly via the using and
+                // avoids the APM BeginConnect/AsyncWaitHandle pattern, which leaks a wait handle.
+                c.ConnectAsync("127.0.0.1", 10002).Wait(TimeSpan.FromMilliseconds(500));
+                return c.Connected;
             }
             catch { return false; }
         }
 
-        [Fact]
+        [SkippableFact]
         public void Azure_RejectsTableNameStartingWithDigit_ButAcceptsRepairedName()
         {
-            if (!AzuriteTablesAvailable()) return;
+            Skip.IfNot(AzuriteTablesAvailable(), "Azurite Table service is not running on 127.0.0.1:10002");
             var svc = new TableServiceClient(DevStorage);
 
             // "123logs" is exactly what the buggy CheckAndRepairTableNamingRules returned.


### PR DESCRIPTION
## Problem
`AzureStorageNameCache.CheckAndRepairTableNamingRules` computed a cleaned table name but then **returned the original input**, so invalid names (leading digit, forbidden chars) were handed to Azure unchanged. It also allowed `-` (table names are alphanumeric only) and threw on a null input.

## Why it's real (not an assumption)
Verified against the real Azure SDK + Azurite: creating a table named `123logs` (the buggy output) is **genuinely rejected**; the repaired `logs` is accepted. See `TableNameRulesTests`.

## Fix
- Return the cleaned name; strip non-alphanumerics; null-guard the input.

## Tests
- `AzureStorageNameCacheTests` — leading-digit, forbidden-char, default-fallback, valid-passthrough, null (reproduced red before the fix).
- `TableNameRulesTests` — Azurite characterization (skips if Azurite absent).

Run tests with `DOTNET_ROLL_FORWARD=Major` (only net9/net10 runtimes here).
