### PR TITLE
Fix off-by-one truncation of max-length Azure Table string values

### DIFF
--- a/src/NLog.Extensions.AzureDataTables/DataTablesTarget.cs
+++ b/src/NLog.Extensions.AzureDataTables/DataTablesTarget.cs
@@ -415,10 +415,10 @@ namespace NLog.Targets
                     if (!contextproperty.IncludeEmptyValue && string.IsNullOrEmpty(propertyValue))
                         continue;
 
-                    if (propertyValue.Length >= ColumnStringValueMaxSize)
+                    if (propertyValue.Length > ColumnStringValueMaxSize)
                     {
                         InternalLogger.Debug("AzureDataTablesTarget(Name={0}): Truncating value from column '{1}', because string-length above 32K", Name, contextproperty.Name);
-                        propertyValue = propertyValue.Substring(0, ColumnStringValueMaxSize - 1);
+                        propertyValue = propertyValue.Substring(0, ColumnStringValueMaxSize);
                     }
 
                     entity.Add(contextproperty.Name, propertyValue);
@@ -429,9 +429,9 @@ namespace NLog.Targets
             else
             {
                 var layoutMessage = RenderLogEvent(Layout, logEvent) ?? string.Empty;
-                if (layoutMessage.Length >= ColumnStringValueMaxSize)
+                if (layoutMessage.Length > ColumnStringValueMaxSize)
                 {
-                    layoutMessage = layoutMessage.Substring(0, ColumnStringValueMaxSize - 1);
+                    layoutMessage = layoutMessage.Substring(0, ColumnStringValueMaxSize);
                     InternalLogger.Debug("AzureDataTablesTarget(Name={0}): Truncating value from Layout, because string-length above 32K", Name);
                 }
                 return new NLogEntity(logEvent, layoutMessage, _machineName, partitionKey, rowKey, LogTimeStampFormat);

--- a/src/NLog.Extensions.AzureDataTables/NLogEntity.cs
+++ b/src/NLog.Extensions.AzureDataTables/NLogEntity.cs
@@ -119,8 +119,8 @@ namespace NLog.Extensions.AzureStorage
 
         private static string TruncateWhenTooBig(string stringValue)
         {
-             return stringValue?.Length >= Targets.DataTablesTarget.ColumnStringValueMaxSize ?
-                stringValue.Substring(0, Targets.DataTablesTarget.ColumnStringValueMaxSize - 1) : stringValue;
+             return stringValue?.Length > Targets.DataTablesTarget.ColumnStringValueMaxSize ?
+                stringValue.Substring(0, Targets.DataTablesTarget.ColumnStringValueMaxSize) : stringValue;
         }
 
         /// <summary>

--- a/src/NLog.Extensions.AzureDataTables/NLogEntity.cs
+++ b/src/NLog.Extensions.AzureDataTables/NLogEntity.cs
@@ -119,7 +119,7 @@ namespace NLog.Extensions.AzureStorage
 
         private static string TruncateWhenTooBig(string stringValue)
         {
-             return stringValue?.Length > Targets.DataTablesTarget.ColumnStringValueMaxSize ?
+            return stringValue?.Length > Targets.DataTablesTarget.ColumnStringValueMaxSize ?
                 stringValue.Substring(0, Targets.DataTablesTarget.ColumnStringValueMaxSize) : stringValue;
         }
 

--- a/test/NLog.Extensions.AzureDataTables.Tests/DataTablesTruncationTests.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/DataTablesTruncationTests.cs
@@ -77,5 +77,26 @@ namespace NLog.Extensions.AzureTableStorage.Tests
             var entity = cloudTableService.PeekLastAdded("Test").Cast<NLogEntity>().First();
             Assert.Equal(MaxSize, entity.FullMessage.Length);
         }
+
+        [Fact]
+        public void Message_AboveMaxSize_IsCappedAtMax()
+        {
+            var logFactory = new LogFactory();
+            var logConfig = new Config.LoggingConfiguration(logFactory);
+            logConfig.Variables["ConnectionString"] = nameof(DataTablesTruncationTests);
+            var cloudTableService = new CloudTableServiceMock();
+            var target = new DataTablesTarget(cloudTableService); // no context properties -> NLogEntity path
+            target.ConnectionString = "${var:ConnectionString}";
+            target.TableName = "${logger}";
+            target.Layout = "${message}";
+            logConfig.AddRuleForAllLevels(target);
+            logFactory.Configuration = logConfig;
+
+            logFactory.GetLogger("Test").Info(new string('y', MaxSize + 5000));
+            logFactory.Flush();
+
+            var entity = cloudTableService.PeekLastAdded("Test").Cast<NLogEntity>().First();
+            Assert.Equal(MaxSize, entity.FullMessage.Length);
+        }
     }
 }

--- a/test/NLog.Extensions.AzureDataTables.Tests/DataTablesTruncationTests.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/DataTablesTruncationTests.cs
@@ -1,0 +1,81 @@
+using System.Linq;
+using Azure.Data.Tables;
+using NLog.Extensions.AzureStorage;
+using NLog.Targets;
+using Xunit;
+
+namespace NLog.Extensions.AzureTableStorage.Tests
+{
+    // Azure Table string properties may hold up to ColumnStringValueMaxSize (32768)
+    // UTF-16 chars. A value of exactly that length is legal and must NOT be truncated;
+    // a longer value must be capped at exactly the max (not max-1).
+    public class DataTablesTruncationTests
+    {
+        private const int MaxSize = 32768; // DataTablesTarget.ColumnStringValueMaxSize
+
+        [Fact]
+        public void ContextProperty_ExactlyMaxSize_IsNotTruncated()
+        {
+            var logFactory = new LogFactory();
+            var logConfig = new Config.LoggingConfiguration(logFactory);
+            logConfig.Variables["ConnectionString"] = nameof(DataTablesTruncationTests);
+            var cloudTableService = new CloudTableServiceMock();
+            var target = new DataTablesTarget(cloudTableService);
+            target.ConnectionString = "${var:ConnectionString}";
+            target.TableName = "${logger}";
+            target.Layout = "${message}";
+            target.ContextProperties.Add(new TargetPropertyWithContext("Big", new string('x', MaxSize)));
+            logConfig.AddRuleForAllLevels(target);
+            logFactory.Configuration = logConfig;
+
+            logFactory.GetLogger("Test").Info("hello");
+            logFactory.Flush();
+
+            var entity = cloudTableService.PeekLastAdded("Test").Cast<TableEntity>().First();
+            Assert.Equal(MaxSize, entity["Big"].ToString().Length);
+        }
+
+        [Fact]
+        public void ContextProperty_AboveMaxSize_IsCappedAtMax()
+        {
+            var logFactory = new LogFactory();
+            var logConfig = new Config.LoggingConfiguration(logFactory);
+            logConfig.Variables["ConnectionString"] = nameof(DataTablesTruncationTests);
+            var cloudTableService = new CloudTableServiceMock();
+            var target = new DataTablesTarget(cloudTableService);
+            target.ConnectionString = "${var:ConnectionString}";
+            target.TableName = "${logger}";
+            target.Layout = "${message}";
+            target.ContextProperties.Add(new TargetPropertyWithContext("Big", new string('x', MaxSize + 5000)));
+            logConfig.AddRuleForAllLevels(target);
+            logFactory.Configuration = logConfig;
+
+            logFactory.GetLogger("Test").Info("hello");
+            logFactory.Flush();
+
+            var entity = cloudTableService.PeekLastAdded("Test").Cast<TableEntity>().First();
+            Assert.Equal(MaxSize, entity["Big"].ToString().Length);
+        }
+
+        [Fact]
+        public void Message_ExactlyMaxSize_IsNotTruncated()
+        {
+            var logFactory = new LogFactory();
+            var logConfig = new Config.LoggingConfiguration(logFactory);
+            logConfig.Variables["ConnectionString"] = nameof(DataTablesTruncationTests);
+            var cloudTableService = new CloudTableServiceMock();
+            var target = new DataTablesTarget(cloudTableService); // no context properties -> NLogEntity path
+            target.ConnectionString = "${var:ConnectionString}";
+            target.TableName = "${logger}";
+            target.Layout = "${message}";
+            logConfig.AddRuleForAllLevels(target);
+            logFactory.Configuration = logConfig;
+
+            logFactory.GetLogger("Test").Info(new string('y', MaxSize));
+            logFactory.Flush();
+
+            var entity = cloudTableService.PeekLastAdded("Test").Cast<NLogEntity>().First();
+            Assert.Equal(MaxSize, entity.FullMessage.Length);
+        }
+    }
+}

--- a/test/NLog.Extensions.AzureDataTables.Tests/NLog.Extensions.AzureDataTables.Tests.csproj
+++ b/test/NLog.Extensions.AzureDataTables.Tests/NLog.Extensions.AzureDataTables.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/test/NLog.Extensions.AzureDataTables.Tests/StringSizeRulesTests.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/StringSizeRulesTests.cs
@@ -18,15 +18,21 @@ namespace NLog.Extensions.AzureTableStorage.Tests
             {
                 using var c = new TcpClient();
                 var r = c.BeginConnect("127.0.0.1", 10002, null, null);
-                return r.AsyncWaitHandle.WaitOne(TimeSpan.FromMilliseconds(500)) && c.Connected;
+                using (r.AsyncWaitHandle)
+                {
+                    if (!r.AsyncWaitHandle.WaitOne(TimeSpan.FromMilliseconds(500)))
+                        return false;
+                    c.EndConnect(r); // surfaces socket errors instead of hiding them
+                    return c.Connected;
+                }
             }
             catch { return false; }
         }
 
-        [Fact]
+        [SkippableFact]
         public void Azure_Accepts32768CharStringProperty()
         {
-            if (!AzuriteTablesAvailable()) return;
+            Skip.IfNot(AzuriteTablesAvailable(), "Azurite Tables emulator not reachable on 127.0.0.1:10002");
             var svc = new TableServiceClient(DevStorage);
             var tableName = "v" + Guid.NewGuid().ToString("n");
             svc.CreateTable(tableName);

--- a/test/NLog.Extensions.AzureDataTables.Tests/StringSizeRulesTests.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/StringSizeRulesTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Net.Sockets;
+using Azure.Data.Tables;
+using Xunit;
+
+namespace NLog.Extensions.AzureTableStorage.Tests
+{
+    // Characterizes REAL Azure Table behavior (via Azurite) to confirm this is a genuine issue:
+    // a 32768-char string property is genuinely accepted and round-trips, so truncating it to
+    // 32767 really was unnecessary data loss (and the fix is not over-permissive).
+    public class StringSizeRulesTests
+    {
+        private const string DevStorage = "UseDevelopmentStorage=true";
+
+        private static bool AzuriteTablesAvailable()
+        {
+            try
+            {
+                using var c = new TcpClient();
+                var r = c.BeginConnect("127.0.0.1", 10002, null, null);
+                return r.AsyncWaitHandle.WaitOne(TimeSpan.FromMilliseconds(500)) && c.Connected;
+            }
+            catch { return false; }
+        }
+
+        [Fact]
+        public void Azure_Accepts32768CharStringProperty()
+        {
+            if (!AzuriteTablesAvailable()) return;
+            var svc = new TableServiceClient(DevStorage);
+            var tableName = "v" + Guid.NewGuid().ToString("n");
+            svc.CreateTable(tableName);
+            try
+            {
+                var table = svc.GetTableClient(tableName);
+                var big = new string('x', 32768); // exactly the constant the code caps at
+                table.UpsertEntity(new TableEntity("pk", "rk") { ["Big"] = big });
+
+                var read = table.GetEntity<TableEntity>("pk", "rk").Value;
+                Assert.Equal(32768, read.GetString("Big").Length); // round-trips intact
+            }
+            finally
+            {
+                svc.DeleteTable(tableName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Azure Table string properties were compared with `>= ColumnStringValueMaxSize` (32768) and truncated to `Substring(0, MaxSize - 1)`, so a **legal 32768-char value was needlessly cut to 32767**, and over-max values were capped one char short. Three sites: `DataTablesTarget` (context-property + layout paths) and `NLogEntity.TruncateWhenTooBig`.

## Why it's real (not an assumption)
Verified against Azurite: a 32768-char string property is **genuinely accepted and round-trips intact** (`StringSizeRulesTests`), so the old cap dropped a character Azure would have stored.

## Fix
Use `> MaxSize` and `Substring(0, MaxSize)` at all three sites (cap at exactly the max).

## Tests
- `DataTablesTruncationTests` — exact-max and above-max, for both the context-property and message (`NLogEntity`) paths (reproduced red at 32767 before the fix).
- `StringSizeRulesTests` — Azurite characterization (skips if Azurite absent).

Run tests with `DOTNET_ROLL_FORWARD=Major`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)