### PR TITLE
Fix silent log loss from un-unwrapped Task<Task> on cache-miss path

### DIFF
--- a/src/NLog.Extensions.AzureBlobStorage/BlobStorageTarget.cs
+++ b/src/NLog.Extensions.AzureBlobStorage/BlobStorageTarget.cs
@@ -475,7 +475,7 @@ namespace NLog.Targets
             }
         }
 
-        private sealed class CloudBlobService : ICloudBlobService
+        internal sealed class CloudBlobService : ICloudBlobService
         {
             private IDictionary<string, string> _blobMetadata;
             private IDictionary<string, string> _blobTags;
@@ -526,7 +526,7 @@ namespace NLog.Targets
                 return null;
             }
 
-            public Task AppendFromByteArrayAsync(string containerName, string blobName, string contentType, byte[] buffer, CancellationToken cancellationToken)
+            public async Task AppendFromByteArrayAsync(string containerName, string blobName, string contentType, byte[] buffer, CancellationToken cancellationToken)
             {
                 var stream = new System.IO.MemoryStream(buffer);
 
@@ -534,12 +534,10 @@ namespace NLog.Targets
                 var container = _container;
                 if (string.IsNullOrEmpty(containerName) || container?.Name != containerName || string.IsNullOrEmpty(blobName) || blob?.Name != blobName)
                 {
-                    return InitializeAndCacheBlobAsync(containerName, blobName, contentType, cancellationToken).ContinueWith(async (t, s) => await t.Result.AppendBlockAsync((System.IO.Stream)s, null).ConfigureAwait(false), stream, cancellationToken);
+                    blob = await InitializeAndCacheBlobAsync(containerName, blobName, contentType, cancellationToken).ConfigureAwait(false);
                 }
-                else
-                {
-                    return blob.AppendBlockAsync(stream, cancellationToken: cancellationToken);
-                }
+
+                await blob.AppendBlockAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
 
             async Task<AppendBlobClient> InitializeAndCacheBlobAsync(string containerName, string blobName, string contentType, CancellationToken cancellationToken)

--- a/src/NLog.Extensions.AzureBlobStorage/BlobStorageTarget.cs
+++ b/src/NLog.Extensions.AzureBlobStorage/BlobStorageTarget.cs
@@ -528,16 +528,17 @@ namespace NLog.Targets
 
             public async Task AppendFromByteArrayAsync(string containerName, string blobName, string contentType, byte[] buffer, CancellationToken cancellationToken)
             {
-                var stream = new System.IO.MemoryStream(buffer);
-
-                var blob = _appendBlob;
-                var container = _container;
-                if (string.IsNullOrEmpty(containerName) || container?.Name != containerName || string.IsNullOrEmpty(blobName) || blob?.Name != blobName)
+                using (var stream = new System.IO.MemoryStream(buffer))
                 {
-                    blob = await InitializeAndCacheBlobAsync(containerName, blobName, contentType, cancellationToken).ConfigureAwait(false);
-                }
+                    var blob = _appendBlob;
+                    var container = _container;
+                    if (string.IsNullOrEmpty(containerName) || container?.Name != containerName || string.IsNullOrEmpty(blobName) || blob?.Name != blobName)
+                    {
+                        blob = await InitializeAndCacheBlobAsync(containerName, blobName, contentType, cancellationToken).ConfigureAwait(false);
+                    }
 
-                await blob.AppendBlockAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    await blob.AppendBlockAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
             }
 
             async Task<AppendBlobClient> InitializeAndCacheBlobAsync(string containerName, string blobName, string contentType, CancellationToken cancellationToken)

--- a/src/NLog.Extensions.AzureDataTables/DataTablesTarget.cs
+++ b/src/NLog.Extensions.AzureDataTables/DataTablesTarget.cs
@@ -485,7 +485,7 @@ namespace NLog.Targets
             }
         }
 
-        private sealed class CloudTableService : ICloudTableService
+        internal sealed class CloudTableService : ICloudTableService
         {
             private TableServiceClient _client;
             private TableClient _table;
@@ -530,17 +530,15 @@ namespace NLog.Targets
                 return null;
             }
 
-            public Task SubmitTransactionAsync(string tableName, IEnumerable<TableTransactionAction> tableTransaction, CancellationToken cancellationToken)
+            public async Task SubmitTransactionAsync(string tableName, IEnumerable<TableTransactionAction> tableTransaction, CancellationToken cancellationToken)
             {
                 var table = _table;
                 if (string.IsNullOrEmpty(tableName) || table?.Name != tableName)
                 {
-                    return InitializeAndCacheTableAsync(tableName, cancellationToken).ContinueWith(async (t, operation) => await t.Result.SubmitTransactionAsync((IEnumerable<TableTransactionAction>)operation).ConfigureAwait(false), tableTransaction, cancellationToken);
+                    table = await InitializeAndCacheTableAsync(tableName, cancellationToken).ConfigureAwait(false);
                 }
-                else
-                {
-                    return table.SubmitTransactionAsync(tableTransaction, cancellationToken);
-                }
+
+                await table.SubmitTransactionAsync(tableTransaction, cancellationToken).ConfigureAwait(false);
             }
 
             async Task<TableClient> InitializeAndCacheTableAsync(string tableName, CancellationToken cancellationToken)

--- a/src/NLog.Extensions.AzureQueueStorage/QueueStorageTarget.cs
+++ b/src/NLog.Extensions.AzureQueueStorage/QueueStorageTarget.cs
@@ -332,7 +332,7 @@ namespace NLog.Targets
             return validQueueName;
         }
 
-        private sealed class CloudQueueService : ICloudQueueService
+        internal sealed class CloudQueueService : ICloudQueueService
         {
             private QueueServiceClient _client;
             private QueueClient _queue;
@@ -381,17 +381,15 @@ namespace NLog.Targets
                 return null;
             }
 
-            public Task AddMessageAsync(string queueName, string queueMessage, CancellationToken cancellationToken)
+            public async Task AddMessageAsync(string queueName, string queueMessage, CancellationToken cancellationToken)
             {
                 var queue = _queue;
                 if (string.IsNullOrEmpty(queueName) || queue?.Name != queueName)
                 {
-                    return InitializeAndCacheQueueAsync(queueName, cancellationToken).ContinueWith(async (t, m) => await t.Result.SendMessageAsync((string)m, null, _timeToLive, cancellationToken).ConfigureAwait(false), queueMessage, cancellationToken);
+                    queue = await InitializeAndCacheQueueAsync(queueName, cancellationToken).ConfigureAwait(false);
                 }
-                else
-                {
-                    return queue.SendMessageAsync(queueMessage, null, _timeToLive, cancellationToken);
-                }
+
+                await queue.SendMessageAsync(queueMessage, null, _timeToLive, cancellationToken).ConfigureAwait(false);
             }
 
             private async Task<QueueClient> InitializeAndCacheQueueAsync(string queueName, CancellationToken cancellationToken)

--- a/test/NLog.Extensions.AzureBlobStorage.Tests/BlobStorageSilentLossTests.cs
+++ b/test/NLog.Extensions.AzureBlobStorage.Tests/BlobStorageSilentLossTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs;
+using NLog.Targets;
+using Xunit;
+
+namespace NLog.Extensions.AzureBlobStorage.Tests
+{
+    // Regression tests for S1: the cache-miss write path used
+    //     InitializeAndCacheBlobAsync(...).ContinueWith(async (t, s) => await t.Result.AppendBlockAsync(...))
+    // which returns an un-unwrapped Task<Task>. The returned task completes as soon
+    // as the inner append is *created*, and any failure lands on the orphaned inner
+    // task -> exceptions were swallowed and logs silently lost.
+    public class BlobStorageSilentLossTests
+    {
+        private static void Connect(BlobStorageTarget.CloudBlobService service, string connectionString)
+        {
+            service.Connect(connectionString, null, null, null, null, null, null, null, null, null, null, null);
+        }
+
+        private static bool AzuriteAvailable(int port = 10000)
+        {
+            try
+            {
+                using var client = new TcpClient();
+                var result = client.BeginConnect("127.0.0.1", port, null, null);
+                return result.AsyncWaitHandle.WaitOne(TimeSpan.FromMilliseconds(500)) && client.Connected;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        [Fact]
+        public async Task FirstWriteFailure_FaultsReturnedTask_NotSilentlySwallowed()
+        {
+            // Point at a closed port so the first (cache-miss) append fails deterministically.
+            const string deadEndpoint =
+                "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;" +
+                "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;" +
+                "BlobEndpoint=http://127.0.0.1:1/devstoreaccount1;";
+
+            var service = new BlobStorageTarget.CloudBlobService();
+            Connect(service, deadEndpoint);
+
+            // Before the fix this completes successfully (the failure is swallowed on the
+            // orphaned inner task); after the fix the returned task faults.
+            await Assert.ThrowsAnyAsync<Exception>(() =>
+                service.AppendFromByteArrayAsync("nlogcontainer", "test.log", "text/plain",
+                    Encoding.UTF8.GetBytes("hello"), CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task HappyPath_AppendWritesBlobContent()
+        {
+            if (!AzuriteAvailable())
+                return; // integration test: requires Azurite on 127.0.0.1:10000
+
+            const string devStorage = "UseDevelopmentStorage=true";
+            var container = "nlog" + Guid.NewGuid().ToString("n"); // unique -> no cross-run accumulation
+
+            var service = new BlobStorageTarget.CloudBlobService();
+            Connect(service, devStorage);
+
+            await service.AppendFromByteArrayAsync(container, "test.log", "text/plain",
+                Encoding.UTF8.GetBytes("Hello S1"), CancellationToken.None);
+
+            var verify = new BlobServiceClient(devStorage)
+                .GetBlobContainerClient(container)
+                .GetBlobClient("test.log");
+            var downloaded = await verify.DownloadContentAsync();
+            Assert.Equal("Hello S1", downloaded.Value.Content.ToString());
+
+            // cleanup
+            await new BlobServiceClient(devStorage).GetBlobContainerClient(container).DeleteIfExistsAsync();
+        }
+    }
+}

--- a/test/NLog.Extensions.AzureBlobStorage.Tests/BlobStorageSilentLossTests.cs
+++ b/test/NLog.Extensions.AzureBlobStorage.Tests/BlobStorageSilentLossTests.cs
@@ -21,13 +21,14 @@ namespace NLog.Extensions.AzureBlobStorage.Tests
             service.Connect(connectionString, null, null, null, null, null, null, null, null, null, null, null);
         }
 
-        private static bool AzuriteAvailable(int port = 10000)
+        private static async Task<bool> AzuriteAvailableAsync(int port = 10000)
         {
             try
             {
                 using var client = new TcpClient();
-                var result = client.BeginConnect("127.0.0.1", port, null, null);
-                return result.AsyncWaitHandle.WaitOne(TimeSpan.FromMilliseconds(500)) && client.Connected;
+                using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+                await client.ConnectAsync("127.0.0.1", port, cts.Token).ConfigureAwait(false);
+                return client.Connected;
             }
             catch
             {
@@ -54,11 +55,11 @@ namespace NLog.Extensions.AzureBlobStorage.Tests
                     Encoding.UTF8.GetBytes("hello"), CancellationToken.None));
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task HappyPath_AppendWritesBlobContent()
         {
-            if (!AzuriteAvailable())
-                return; // integration test: requires Azurite on 127.0.0.1:10000
+            // integration test: requires Azurite on 127.0.0.1:10000 -> report as skipped, not passed, when absent
+            Skip.IfNot(await AzuriteAvailableAsync(), "Azurite not reachable on 127.0.0.1:10000");
 
             const string devStorage = "UseDevelopmentStorage=true";
             var container = "nlog" + Guid.NewGuid().ToString("n"); // unique -> no cross-run accumulation

--- a/test/NLog.Extensions.AzureBlobStorage.Tests/NLog.Extensions.AzureBlobStorage.Tests.csproj
+++ b/test/NLog.Extensions.AzureBlobStorage.Tests/NLog.Extensions.AzureBlobStorage.Tests.csproj
@@ -13,6 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NLog.Extensions.AzureDataTables.Tests/DataTablesSilentLossTests.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/DataTablesSilentLossTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Data.Tables;
+using NLog.Targets;
+using Xunit;
+
+namespace NLog.Extensions.AzureTableStorage.Tests
+{
+    // Regression test for S1: the cache-miss submit path returned an un-unwrapped
+    // Task<Task> (ContinueWith with an async lambda), so a first-write failure was
+    // swallowed on the orphaned inner task and table rows were silently lost.
+    public class DataTablesSilentLossTests
+    {
+        [Fact]
+        public async Task FirstWriteFailure_FaultsReturnedTask_NotSilentlySwallowed()
+        {
+            // Point at a closed port so the first (cache-miss) transaction fails deterministically.
+            const string deadEndpoint =
+                "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;" +
+                "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;" +
+                "TableEndpoint=http://127.0.0.1:1/devstoreaccount1;";
+
+            var service = new DataTablesTarget.CloudTableService();
+            service.Connect(deadEndpoint, null, null, null, null, null, null, null, null, null);
+
+            var actions = new[]
+            {
+                new TableTransactionAction(TableTransactionActionType.Add, new TableEntity("pk", "rk")),
+            };
+
+            await Assert.ThrowsAnyAsync<Exception>(() =>
+                service.SubmitTransactionAsync("nlogtable", actions, CancellationToken.None));
+        }
+    }
+}

--- a/test/NLog.Extensions.AzureQueueStorage.Tests/QueueStorageSilentLossTests.cs
+++ b/test/NLog.Extensions.AzureQueueStorage.Tests/QueueStorageSilentLossTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NLog.Targets;
+using Xunit;
+
+namespace NLog.Extensions.AzureQueueStorage.Tests
+{
+    // Regression test for S1: the cache-miss send path returned an un-unwrapped
+    // Task<Task> (ContinueWith with an async lambda), so a first-write failure was
+    // swallowed on the orphaned inner task and messages were silently lost.
+    public class QueueStorageSilentLossTests
+    {
+        [Fact]
+        public async Task FirstWriteFailure_FaultsReturnedTask_NotSilentlySwallowed()
+        {
+            // Point at a closed port so the first (cache-miss) send fails deterministically.
+            const string deadEndpoint =
+                "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;" +
+                "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;" +
+                "QueueEndpoint=http://127.0.0.1:1/devstoreaccount1;";
+
+            var service = new QueueStorageTarget.CloudQueueService();
+            service.Connect(deadEndpoint, null, null, null, null, null, null, null, null, null, null, null);
+
+            await Assert.ThrowsAnyAsync<Exception>(() =>
+                service.AddMessageAsync("nlogqueue", "hello", CancellationToken.None));
+        }
+    }
+}


### PR DESCRIPTION
## Problem (highest-impact)
On the cache-miss path (first write to a given blob/queue/table), Blob/Queue/Tables did:
```csharp
return InitializeAndCacheXAsync(...)
    .ContinueWith(async (t, s) => await t.Result.SendAsync(...));
```
The async continuation makes `ContinueWith` return `Task<Task>`, returned **without `.Unwrap()`**. The outer task completes when the inner send is merely *created*, so:
- NLog treats the batch as flushed before the network write finishes;
- any send failure lands on the orphaned inner task and is **silently swallowed** (logs lost, NLog retry never fires);
- Blob/Tables also dropped the `CancellationToken`.

## Why it's real (not an assumption)
Reproduced against Azurite:
- **Fault test** — connecting the real service to a dead endpoint, `await SendAsync(...)` returned **successfully** (the failure was swallowed). After the fix it faults.
- **Happy path** — a logged message left the blob **empty** (`""`); the `await` returned before `AppendBlockAsync` ran. After the fix the content is written.

## Fix
Rewrote all three send methods as proper `async` methods that await both the initialize-and-cache step and the send, propagating exceptions and the token. The `CloudXService` impls were made `internal` so the tests can drive them directly.

## Tests
`*SilentLossTests` (Blob/Queue/Tables) + a Blob Azurite happy-path test. Both facets reproduced red before the fix.

Run tests with `DOTNET_ROLL_FORWARD=Major`; the Azurite-backed tests skip when Azurite is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)