### PR TITLE
Fix AccessToken refresh storm (no-expiry + failed acquisition)

### DIFF
--- a/src/NLog.Extensions.AzureAccessToken/AccessTokenLayoutRenderer.cs
+++ b/src/NLog.Extensions.AzureAccessToken/AccessTokenLayoutRenderer.cs
@@ -232,9 +232,12 @@ namespace NLog.Extensions.AzureAccessToken
                     // Renew the token 5 minutes before it expires. When the provider returns
                     // no expiry (default DateTimeOffset), fall back to a sane interval instead of
                     // treating the token as expired in year 0001 (which re-fires every 500ms).
-                    nextRefresh = authResult.Value == default(DateTimeOffset)
-                        ? TimeSpan.FromMinutes(55)
-                        : (authResult.Value - DateTimeOffset.UtcNow) - TimeSpan.FromMinutes(5);
+                    if (string.IsNullOrEmpty(authResult.Key))
+                        nextRefresh = TimeSpan.FromSeconds(30);  // Empty token is a failed acquisition - back off and retry instead of waiting ~55 minutes
+                    else if (authResult.Value == default(DateTimeOffset))
+                        nextRefresh = TimeSpan.FromMinutes(55);
+                    else
+                        nextRefresh = (authResult.Value - DateTimeOffset.UtcNow) - TimeSpan.FromMinutes(5);
                 }
                 catch (Exception ex)
                 {

--- a/src/NLog.Extensions.AzureAccessToken/AccessTokenLayoutRenderer.cs
+++ b/src/NLog.Extensions.AzureAccessToken/AccessTokenLayoutRenderer.cs
@@ -229,8 +229,12 @@ namespace NLog.Extensions.AzureAccessToken
                             _accessTokenRefreshed?.Invoke(this, EventArgs.Empty);
                     }
 
-                    // Renew the token 5 minutes before it expires.
-                    nextRefresh = (authResult.Value - DateTimeOffset.UtcNow) - TimeSpan.FromMinutes(5);
+                    // Renew the token 5 minutes before it expires. When the provider returns
+                    // no expiry (default DateTimeOffset), fall back to a sane interval instead of
+                    // treating the token as expired in year 0001 (which re-fires every 500ms).
+                    nextRefresh = authResult.Value == default(DateTimeOffset)
+                        ? TimeSpan.FromMinutes(55)
+                        : (authResult.Value - DateTimeOffset.UtcNow) - TimeSpan.FromMinutes(5);
                 }
                 catch (Exception ex)
                 {

--- a/src/NLog.Extensions.AzureAccessToken/AccessTokenLayoutRenderer.cs
+++ b/src/NLog.Extensions.AzureAccessToken/AccessTokenLayoutRenderer.cs
@@ -239,6 +239,7 @@ namespace NLog.Extensions.AzureAccessToken
                 catch (Exception ex)
                 {
                     InternalLogger.Error(ex, "AccessToken LayoutRenderer - Failed getting AccessToken from AzureServiceTokenProvider");
+                    nextRefresh = TimeSpan.FromSeconds(30);  // Back off after a failure instead of retrying every 500ms
                 }
                 finally
                 {

--- a/test/NLog.Extensions.AzureAccessToken.Tests/AccessTokenLayoutRendererTests.cs
+++ b/test/NLog.Extensions.AzureAccessToken.Tests/AccessTokenLayoutRendererTests.cs
@@ -96,6 +96,8 @@ namespace NLog.Extensions.AzureAccessToken.Tests
             layout.ResetTokenRefresher();
 
             // With the bug: default expiry -> nextRefresh clamps to 500ms -> ~4-5 calls in ~2s.
+            // Lower bound guards against a false pass if the timer never exercised the refresh path.
+            Assert.True(count >= 1, $"Expected the provider to be called at least once, but it was called {count} times in ~2s");
             Assert.True(count <= 2, $"Expected no refresh storm for a default expiry, but the provider was called {count} times in ~2s");
         }
 
@@ -114,6 +116,8 @@ namespace NLog.Extensions.AzureAccessToken.Tests
             layout.ResetTokenRefresher();
 
             // With the bug: failure -> nextRefresh stays 0 -> clamps to 500ms -> ~4-5 calls in ~2s.
+            // Lower bound guards against a false pass if the provider was never invoked.
+            Assert.True(count >= 1, $"Expected the provider to be called at least once, but it was called {count} times in ~2s");
             Assert.True(count <= 2, $"Expected no retry storm after acquisition failure, but the provider was called {count} times in ~2s");
         }
 

--- a/test/NLog.Extensions.AzureAccessToken.Tests/AccessTokenLayoutRendererTests.cs
+++ b/test/NLog.Extensions.AzureAccessToken.Tests/AccessTokenLayoutRendererTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace NLog.Extensions.AzureAccessToken.Tests
@@ -82,7 +83,7 @@ namespace NLog.Extensions.AzureAccessToken.Tests
         }
 
         [Fact]
-        public void DefaultExpiry_DoesNotCauseRefreshStorm()
+        public async Task DefaultExpiry_DoesNotCauseRefreshStorm()
         {
             // When the provider returns no expiry (default DateTimeOffset), the renderer
             // must not schedule the refresh timer to re-fire every 500ms forever.
@@ -91,7 +92,7 @@ namespace NLog.Extensions.AzureAccessToken.Tests
             var layout = new AccessTokenLayoutRenderer((connectionString, azureAdInstance) => provider) { ResourceName = "RefreshStormResource" };
 
             layout.Render(LogEventInfo.CreateNullEvent());  // initial acquire + schedules next refresh
-            System.Threading.Thread.Sleep(2000);
+            await Task.Delay(2000);
             var count = provider.CallCount;
             layout.ResetTokenRefresher();
 
@@ -102,7 +103,7 @@ namespace NLog.Extensions.AzureAccessToken.Tests
         }
 
         [Fact]
-        public void FailedAcquisition_DoesNotCauseRetryStorm()
+        public async Task FailedAcquisition_DoesNotCauseRetryStorm()
         {
             // When token acquisition fails, the renderer must not re-fire the timer every
             // 500ms (hammering the identity endpoint); it should back off to a sane retry.
@@ -111,7 +112,7 @@ namespace NLog.Extensions.AzureAccessToken.Tests
             var layout = new AccessTokenLayoutRenderer((connectionString, azureAdInstance) => provider) { ResourceName = "RetryStormResource" };
 
             layout.Render(LogEventInfo.CreateNullEvent());  // initial acquire fails + schedules retry
-            System.Threading.Thread.Sleep(2000);
+            await Task.Delay(2000);
             var count = provider.CallCount;
             layout.ResetTokenRefresher();
 

--- a/test/NLog.Extensions.AzureAccessToken.Tests/AccessTokenLayoutRendererTests.cs
+++ b/test/NLog.Extensions.AzureAccessToken.Tests/AccessTokenLayoutRendererTests.cs
@@ -81,6 +81,24 @@ namespace NLog.Extensions.AzureAccessToken.Tests
             Assert.True(WaitForTokenTimersStoppedAndGarbageCollected());
         }
 
+        [Fact]
+        public void DefaultExpiry_DoesNotCauseRefreshStorm()
+        {
+            // When the provider returns no expiry (default DateTimeOffset), the renderer
+            // must not schedule the refresh timer to re-fire every 500ms forever.
+            AccessTokenLayoutRenderer.AccessTokenProviders.Clear();
+            var provider = new CountingTokenProviderMock(default(DateTimeOffset));
+            var layout = new AccessTokenLayoutRenderer((connectionString, azureAdInstance) => provider) { ResourceName = "RefreshStormResource" };
+
+            layout.Render(LogEventInfo.CreateNullEvent());  // initial acquire + schedules next refresh
+            System.Threading.Thread.Sleep(2000);
+            var count = provider.CallCount;
+            layout.ResetTokenRefresher();
+
+            // With the bug: default expiry -> nextRefresh clamps to 500ms -> ~4-5 calls in ~2s.
+            Assert.True(count <= 2, $"Expected no refresh storm for a default expiry, but the provider was called {count} times in ~2s");
+        }
+
         private static AccessTokenLayoutRenderer CreateAccessTokenLayoutRenderer(string resourceName = "TestResource", string accessToken = null, TimeSpan? refreshInterval = null)
         {
             NLog.LogManager.ThrowConfigExceptions = true;

--- a/test/NLog.Extensions.AzureAccessToken.Tests/AccessTokenLayoutRendererTests.cs
+++ b/test/NLog.Extensions.AzureAccessToken.Tests/AccessTokenLayoutRendererTests.cs
@@ -99,6 +99,24 @@ namespace NLog.Extensions.AzureAccessToken.Tests
             Assert.True(count <= 2, $"Expected no refresh storm for a default expiry, but the provider was called {count} times in ~2s");
         }
 
+        [Fact]
+        public void FailedAcquisition_DoesNotCauseRetryStorm()
+        {
+            // When token acquisition fails, the renderer must not re-fire the timer every
+            // 500ms (hammering the identity endpoint); it should back off to a sane retry.
+            AccessTokenLayoutRenderer.AccessTokenProviders.Clear();
+            var provider = new ThrowingTokenProviderMock();
+            var layout = new AccessTokenLayoutRenderer((connectionString, azureAdInstance) => provider) { ResourceName = "RetryStormResource" };
+
+            layout.Render(LogEventInfo.CreateNullEvent());  // initial acquire fails + schedules retry
+            System.Threading.Thread.Sleep(2000);
+            var count = provider.CallCount;
+            layout.ResetTokenRefresher();
+
+            // With the bug: failure -> nextRefresh stays 0 -> clamps to 500ms -> ~4-5 calls in ~2s.
+            Assert.True(count <= 2, $"Expected no retry storm after acquisition failure, but the provider was called {count} times in ~2s");
+        }
+
         private static AccessTokenLayoutRenderer CreateAccessTokenLayoutRenderer(string resourceName = "TestResource", string accessToken = null, TimeSpan? refreshInterval = null)
         {
             NLog.LogManager.ThrowConfigExceptions = true;

--- a/test/NLog.Extensions.AzureAccessToken.Tests/CountingTokenProviderMock.cs
+++ b/test/NLog.Extensions.AzureAccessToken.Tests/CountingTokenProviderMock.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NLog.Extensions.AzureAccessToken.Tests
+{
+    // Counts how often a token is requested, and returns a fixed expiry, so a test
+    // can detect a pathological refresh "storm" (timer re-firing every 500ms).
+    class CountingTokenProviderMock : AccessTokenLayoutRenderer.IAzureServiceTokenProviderService
+    {
+        private int _callCount;
+        private readonly DateTimeOffset _expiry;
+
+        public int CallCount => Volatile.Read(ref _callCount);
+
+        public CountingTokenProviderMock(DateTimeOffset expiry)
+        {
+            _expiry = expiry;
+        }
+
+        public async Task<KeyValuePair<string, DateTimeOffset>> GetAuthenticationResultAsync(string resource, string tenantId, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _callCount);
+            await Task.Delay(1, cancellationToken).ConfigureAwait(false);
+            return new KeyValuePair<string, DateTimeOffset>("token", _expiry);
+        }
+    }
+}

--- a/test/NLog.Extensions.AzureAccessToken.Tests/ThrowingTokenProviderMock.cs
+++ b/test/NLog.Extensions.AzureAccessToken.Tests/ThrowingTokenProviderMock.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NLog.Extensions.AzureAccessToken.Tests
+{
+    // Always fails token acquisition, and counts attempts, so a test can detect a
+    // pathological retry "storm" (timer re-firing every 500ms) after a failure.
+    class ThrowingTokenProviderMock : AccessTokenLayoutRenderer.IAzureServiceTokenProviderService
+    {
+        private int _callCount;
+
+        public int CallCount => Volatile.Read(ref _callCount);
+
+        public async Task<KeyValuePair<string, DateTimeOffset>> GetAuthenticationResultAsync(string resource, string tenantId, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _callCount);
+            await Task.Delay(1, cancellationToken).ConfigureAwait(false);
+            throw new InvalidOperationException("simulated token acquisition failure");
+        }
+    }
+}


### PR DESCRIPTION
## Problem
`AccessTokenRefresher` re-scheduled the refresh `Timer` to fire **every 500ms forever** in two cases, hammering the identity endpoint:
1. **No expiry** — when the provider returned a `default(DateTimeOffset)` expiry, `nextRefresh` was computed as `(year-0001 - now) - 5min` (hugely negative) and clamped to the 500ms floor.
2. **Failed acquisition** — on an exception, `nextRefresh` stayed `TimeSpan.Zero` and clamped to 500ms (no backoff), so an auth outage spun at 500ms.

## Why it's real (not an assumption)
Direct measurement (not an Azure-rules claim): a counting token-provider mock was invoked **4–5 times in ~2s** before the fix; **1** after.

## Fix
- No/unknown expiry → fall back to a sane 55-minute interval (near-future real expiries unchanged).
- Failed acquisition → back off to a 30s retry.

## Tests
`DefaultExpiry_DoesNotCauseRefreshStorm`, `FailedAcquisition_DoesNotCauseRetryStorm` (+ `CountingTokenProviderMock`, `ThrowingTokenProviderMock`). Existing near-expiry refresh test still passes, confirming the fix is scoped.

## ⚠️ Pre-existing build note (not introduced here)
The `NLog.Extensions.AzureAccessToken` project fails to build under `TreatWarningsAsErrors` due to **pre-existing missing XML docs (CS1591)** on its public members — independent of this fix. Verified with `-p:TreatWarningsAsErrors=false` (and `DOTNET_ROLL_FORWARD=Major`). That doc gap should be fixed separately to green this package's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)