### PR TITLE
Fix AzureStorageNameCache thread-safety (ConcurrentDictionary)

### DIFF
--- a/src/NLog.Extensions.AzureStorage/AzureStorageNameCache.cs
+++ b/src/NLog.Extensions.AzureStorage/AzureStorageNameCache.cs
@@ -1,12 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
 
 namespace NLog.Extensions.AzureStorage
 {
     internal sealed class AzureStorageNameCache
     {
-        private readonly Dictionary<string, string> _storageNameCache = new Dictionary<string, string>();
+        private readonly ConcurrentDictionary<string, string> _storageNameCache = new ConcurrentDictionary<string, string>();
 
         public string LookupStorageName(string requestedName, Func<string, string> checkAndRepairName)
         {

--- a/test/NLog.Extensions.AzureDataTables.Tests/AzureStorageNameCacheConcurrencyTests.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/AzureStorageNameCacheConcurrencyTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
+using NLog.Extensions.AzureStorage;
+using Xunit;
+
+namespace NLog.Extensions.AzureTableStorage.Tests
+{
+    // S2: AzureStorageNameCache.LookupStorageName reads, Clears, and writes a plain
+    // Dictionary with no synchronization. A single flush fans out bucket tasks via
+    // Task.WhenAll, so the cache is hit concurrently for multiple names. This test
+    // drives that real concurrency and asserts the cache neither throws, hangs, nor
+    // returns a corrupt value.
+    public class AzureStorageNameCacheConcurrencyTests
+    {
+        [Fact]
+        public void LookupStorageName_UnderConcurrentLoad_DoesNotThrowHangOrCorrupt()
+        {
+            var cache = new AzureStorageNameCache();
+            Func<string, string> repair = n => "ok-" + n; // deterministic: name -> "ok-"+name
+            var corrupt = new ConcurrentQueue<string>();
+
+            var work = Task.Run(() =>
+                Parallel.For(0, 300_000, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, i =>
+                {
+                    var name = "n" + (i % 4000);   // > 1000 distinct keys -> exercises the Count>1000 Clear()
+                    var result = cache.LookupStorageName(name, repair);
+                    if (result != "ok-" + name)
+                        corrupt.Enqueue($"{name} -> {result ?? "<null>"}");
+                }));
+
+            bool completed;
+            try
+            {
+                completed = work.Wait(TimeSpan.FromSeconds(30));
+            }
+            catch (Exception ex)
+            {
+                throw new Xunit.Sdk.XunitException("LookupStorageName threw under concurrent access: " + ex.GetBaseException());
+            }
+
+            Assert.True(completed, "LookupStorageName hung under concurrent access (corrupted Dictionary internal state)");
+            Assert.True(corrupt.IsEmpty, $"LookupStorageName returned corrupt values under concurrency, e.g. {corrupt.FirstOrDefault()}");
+        }
+    }
+}

--- a/test/NLog.Extensions.AzureDataTables.Tests/AzureStorageNameCacheConcurrencyTests.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/AzureStorageNameCacheConcurrencyTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NLog.Extensions.AzureStorage;
 using Xunit;
@@ -21,8 +22,18 @@ namespace NLog.Extensions.AzureTableStorage.Tests
             Func<string, string> repair = n => "ok-" + n; // deterministic: name -> "ok-"+name
             var corrupt = new ConcurrentQueue<string>();
 
+            // Tie the timeout to the loop itself: when the token fires, Parallel.For stops
+            // issuing iterations and throws OperationCanceledException, so a hung/corrupt
+            // cache can't leave the 300k-iteration loop spinning after the test fails.
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var options = new ParallelOptions
+            {
+                MaxDegreeOfParallelism = Environment.ProcessorCount,
+                CancellationToken = cts.Token
+            };
+
             var work = Task.Run(() =>
-                Parallel.For(0, 300_000, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, i =>
+                Parallel.For(0, 300_000, options, i =>
                 {
                     var name = "n" + (i % 4000);   // > 1000 distinct keys -> exercises the Count>1000 Clear()
                     var result = cache.LookupStorageName(name, repair);
@@ -30,17 +41,19 @@ namespace NLog.Extensions.AzureTableStorage.Tests
                         corrupt.Enqueue($"{name} -> {result ?? "<null>"}");
                 }));
 
-            bool completed;
             try
             {
-                completed = work.Wait(TimeSpan.FromSeconds(30));
+                work.Wait();
+            }
+            catch (Exception ex) when (ex.GetBaseException() is OperationCanceledException)
+            {
+                throw new Xunit.Sdk.XunitException("LookupStorageName hung under concurrent access (corrupted Dictionary internal state)");
             }
             catch (Exception ex)
             {
                 throw new Xunit.Sdk.XunitException("LookupStorageName threw under concurrent access: " + ex.GetBaseException());
             }
 
-            Assert.True(completed, "LookupStorageName hung under concurrent access (corrupted Dictionary internal state)");
             Assert.True(corrupt.IsEmpty, $"LookupStorageName returned corrupt values under concurrency, e.g. {corrupt.FirstOrDefault()}");
         }
     }


### PR DESCRIPTION
## Problem
`AzureStorageNameCache.LookupStorageName` read, `Count`-checked, `Clear()`ed, and wrote a plain `Dictionary` with no synchronization. A single flush fans out bucket tasks via `Task.WhenAll`, so the cache is hit **concurrently** for multiple container/table/queue names. This shared cache is compiled into all six storage packages.

## Why it's real (not an assumption)
Under a concurrent stress test, the .NET runtime's **own corruption guard** fired (in ~8ms):
```
InvalidOperationException: Operations that change non-concurrent collections must have
exclusive access. A concurrent update ... corrupted its state.
   at System.Collections.Generic.Dictionary`2.FindValue
   at AzureStorageNameCache.LookupStorageName ... line 13
```

## Fix
Backing store → `ConcurrentDictionary` (TryGetValue/Count/Clear/indexer are all thread-safe; the check-then-act eviction races are benign).

## Tests
`AzureStorageNameCacheConcurrencyTests` — 300k lookups across all cores; reproduced the corruption exception before the fix, passes after. (All six storage packages build clean under `TreatWarningsAsErrors`.)

Run tests with `DOTNET_ROLL_FORWARD=Major`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)