### PR TITLE
Sanitize Azure Table PartitionKey/RowKey to prevent whole-batch loss

### DIFF
--- a/src/NLog.Extensions.AzureDataTables/DataTablesTarget.cs
+++ b/src/NLog.Extensions.AzureDataTables/DataTablesTarget.cs
@@ -296,13 +296,17 @@ namespace NLog.Targets
         protected override Task WriteAsyncTask(IList<LogEventInfo> logEvents, CancellationToken cancellationToken)
         {
             //must sort into containers and then into the blobs for the container
+            // Sanitize the PartitionKey at render time (not just when building the entity) so events
+            // whose keys differ only by a forbidden char (e.g. "a/b" vs "a#b") bucket together into a
+            // single transaction, instead of splitting across batches that all target the same
+            // sanitized partition.
             if (_getTablePartitionNameDelegate == null)
-                _getTablePartitionNameDelegate = logEvent => new TablePartitionKey(RenderLogEvent(TableName, logEvent), RenderLogEvent(PartitionKey, logEvent));
+                _getTablePartitionNameDelegate = logEvent => new TablePartitionKey(RenderLogEvent(TableName, logEvent), SanitizeKey(RenderLogEvent(PartitionKey, logEvent)));
 
             if (logEvents.Count == 1)
             {
                 var tableName = RenderLogEvent(TableName, logEvents[0]);
-                var partitionKey = RenderLogEvent(PartitionKey, logEvents[0]);
+                var partitionKey = SanitizeKey(RenderLogEvent(PartitionKey, logEvents[0]));
 
                 try
                 {
@@ -411,7 +415,14 @@ namespace NLog.Targets
 
         private ITableEntity CreateTableEntity(LogEventInfo logEvent, string partitionKey)
         {
-            partitionKey = SanitizeKey(partitionKey);
+            // partitionKey is already sanitized by the caller, so the partition bucket key matches the
+            // written entity key. Only the rowKey is rendered (and sanitized) here.
+            //
+            // Residual: SanitizeKey is lossy, so two distinct rowKeys within one batch can collapse to
+            // the same value (e.g. "id/1" and "id#1" both -> "id_1"). Azure rejects a transaction that
+            // contains duplicate row keys, so that batch is still lost. This is far narrower than the
+            // pre-fix behavior (ANY forbidden char failed the whole batch) and only occurs with custom
+            // RowKey layouts that emit forbidden chars -- the default GUID-based RowKey never collides.
             var rowKey = SanitizeKey(RenderLogEvent(RowKey, logEvent));
 
             if (ContextProperties.Count > 0)

--- a/src/NLog.Extensions.AzureDataTables/DataTablesTarget.cs
+++ b/src/NLog.Extensions.AzureDataTables/DataTablesTarget.cs
@@ -389,9 +389,30 @@ namespace NLog.Targets
             return _cloudTableService.SubmitTransactionAsync(tableName, tableTransaction, cancellationToken);
         }
 
+        // Azure Table keys may not contain '/', '\', '#', '?' or control chars; such a key makes
+        // Azure reject the whole transaction (losing the entire batch). Replace them with '_'.
+        private static string SanitizeKey(string key)
+        {
+            if (string.IsNullOrEmpty(key))
+                return key;
+
+            char[] buffer = null;
+            for (int i = 0; i < key.Length; ++i)
+            {
+                char c = key[i];
+                if (c == '/' || c == '\\' || c == '#' || c == '?' || c < 0x20 || (c >= 0x7F && c <= 0x9F))
+                {
+                    buffer = buffer ?? key.ToCharArray();
+                    buffer[i] = '_';
+                }
+            }
+            return buffer == null ? key : new string(buffer);
+        }
+
         private ITableEntity CreateTableEntity(LogEventInfo logEvent, string partitionKey)
         {
-            var rowKey = RenderLogEvent(RowKey, logEvent);
+            partitionKey = SanitizeKey(partitionKey);
+            var rowKey = SanitizeKey(RenderLogEvent(RowKey, logEvent));
 
             if (ContextProperties.Count > 0)
             {

--- a/test/NLog.Extensions.AzureDataTables.Tests/DataTablesKeySanitizationTests.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/DataTablesKeySanitizationTests.cs
@@ -6,7 +6,7 @@ namespace NLog.Extensions.AzureTableStorage.Tests
 {
     // Azure rejects an entire table transaction if any PartitionKey/RowKey contains a
     // forbidden character (/ \ # ?) or a control char -- losing every (valid) log entry
-    // in that batch (proven in AzureRulesValidationTests against Azurite). The target must
+    // in that batch (proven in KeyCharacterRulesTests against Azurite). The target must
     // therefore sanitize rendered keys before building the entity.
     public class DataTablesKeySanitizationTests
     {

--- a/test/NLog.Extensions.AzureDataTables.Tests/DataTablesKeySanitizationTests.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/DataTablesKeySanitizationTests.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using NLog.Targets;
+using Xunit;
+
+namespace NLog.Extensions.AzureTableStorage.Tests
+{
+    // Azure rejects an entire table transaction if any PartitionKey/RowKey contains a
+    // forbidden character (/ \ # ?) or a control char -- losing every (valid) log entry
+    // in that batch (proven in AzureRulesValidationTests against Azurite). The target must
+    // therefore sanitize rendered keys before building the entity.
+    public class DataTablesKeySanitizationTests
+    {
+        [Fact]
+        public void ForbiddenCharactersInKeys_AreSanitized()
+        {
+            var logFactory = new LogFactory();
+            var logConfig = new Config.LoggingConfiguration(logFactory);
+            logConfig.Variables["ConnectionString"] = nameof(DataTablesKeySanitizationTests);
+            var svc = new CloudTableServiceMock();
+            var target = new DataTablesTarget(svc);
+            target.ConnectionString = "${var:ConnectionString}";
+            target.TableName = "${logger}";
+            target.PartitionKey = "pk/with#bad";   // '/' and '#' are forbidden in keys
+            target.RowKey = "row?with\\bad";        // '?' and '\' are forbidden in keys
+            target.Layout = "${message}";
+            logConfig.AddRuleForAllLevels(target);
+            logFactory.Configuration = logConfig;
+
+            logFactory.GetLogger("Test").Info("hi");
+            logFactory.Flush();
+
+            var entity = svc.PeekLastAdded("Test").First();
+            foreach (var bad in new[] { "/", "\\", "#", "?" })
+            {
+                Assert.DoesNotContain(bad, entity.PartitionKey);
+                Assert.DoesNotContain(bad, entity.RowKey);
+            }
+        }
+    }
+}

--- a/test/NLog.Extensions.AzureDataTables.Tests/KeyCharacterRulesTests.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/KeyCharacterRulesTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.Sockets;
+using Azure;
 using Azure.Data.Tables;
 using Xunit;
 
@@ -23,10 +24,10 @@ namespace NLog.Extensions.AzureTableStorage.Tests
             catch { return false; }
         }
 
-        [Fact]
+        [SkippableFact]
         public void Azure_ForbiddenKeyCharInBatch_RejectsWholeTransaction_LosingGoodEntitiesToo()
         {
-            if (!AzuriteTablesAvailable()) return;
+            Skip.IfNot(AzuriteTablesAvailable(), "Azurite Tables endpoint (127.0.0.1:10002) is not available.");
             var svc = new TableServiceClient(DevStorage);
             var tableName = "k" + Guid.NewGuid().ToString("n");
             svc.CreateTable(tableName);
@@ -40,10 +41,13 @@ namespace NLog.Extensions.AzureTableStorage.Tests
                 };
 
                 // The whole transaction is rejected because of the one forbidden RowKey.
-                Assert.NotNull(Record.Exception(() => table.SubmitTransaction(actions)));
+                // (TableTransactionFailedException derives from RequestFailedException.)
+                Assert.ThrowsAny<RequestFailedException>(() => table.SubmitTransaction(actions));
 
-                // ...and the VALID log entry in the same batch was lost too (never committed).
-                Assert.NotNull(Record.Exception(() => table.GetEntity<TableEntity>("pk", "good-row")));
+                // ...and the VALID log entry in the same batch was lost too (never committed):
+                // reading it back yields a 404, proving it was never persisted.
+                var readBack = Assert.ThrowsAny<RequestFailedException>(() => table.GetEntity<TableEntity>("pk", "good-row"));
+                Assert.Equal(404, readBack.Status);
             }
             finally
             {

--- a/test/NLog.Extensions.AzureDataTables.Tests/KeyCharacterRulesTests.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/KeyCharacterRulesTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Net.Sockets;
+using Azure.Data.Tables;
+using Xunit;
+
+namespace NLog.Extensions.AzureTableStorage.Tests
+{
+    // Characterizes REAL Azure Table behavior (via Azurite) to confirm this is a genuine issue:
+    // a forbidden key character ('/') makes Azure reject the ENTIRE transaction, so a single bad
+    // key loses every valid log entry in the same batch -> the target must sanitize keys.
+    public class KeyCharacterRulesTests
+    {
+        private const string DevStorage = "UseDevelopmentStorage=true";
+
+        private static bool AzuriteTablesAvailable()
+        {
+            try
+            {
+                using var c = new TcpClient();
+                var r = c.BeginConnect("127.0.0.1", 10002, null, null);
+                return r.AsyncWaitHandle.WaitOne(TimeSpan.FromMilliseconds(500)) && c.Connected;
+            }
+            catch { return false; }
+        }
+
+        [Fact]
+        public void Azure_ForbiddenKeyCharInBatch_RejectsWholeTransaction_LosingGoodEntitiesToo()
+        {
+            if (!AzuriteTablesAvailable()) return;
+            var svc = new TableServiceClient(DevStorage);
+            var tableName = "k" + Guid.NewGuid().ToString("n");
+            svc.CreateTable(tableName);
+            try
+            {
+                var table = svc.GetTableClient(tableName);
+                var actions = new[]
+                {
+                    new TableTransactionAction(TableTransactionActionType.Add, new TableEntity("pk", "good-row")),
+                    new TableTransactionAction(TableTransactionActionType.Add, new TableEntity("pk", "bad/row")), // '/' is forbidden in keys
+                };
+
+                // The whole transaction is rejected because of the one forbidden RowKey.
+                Assert.NotNull(Record.Exception(() => table.SubmitTransaction(actions)));
+
+                // ...and the VALID log entry in the same batch was lost too (never committed).
+                Assert.NotNull(Record.Exception(() => table.GetEntity<TableEntity>("pk", "good-row")));
+            }
+            finally
+            {
+                svc.DeleteTable(tableName);
+            }
+        }
+    }
+}

--- a/test/NLog.Extensions.AzureDataTables.Tests/NLog.Extensions.AzureDataTables.Tests.csproj
+++ b/test/NLog.Extensions.AzureDataTables.Tests/NLog.Extensions.AzureDataTables.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
## Problem
A `PartitionKey`/`RowKey` containing `/`, `\`, `#`, `?` or a control char makes Azure **reject the entire table transaction** — so a single bad key (e.g. a `RowKey` rendered from `${aspnet-request-url}`) silently loses **every valid log entry** in that batch. The target passed rendered keys straight through, unsanitized.

## Why it's real (not an assumption)
Proven against Azurite (`KeyCharacterRulesTests`): a batch with one good entity + one `bad/row` entity is rejected wholesale, and the **good entity is never committed** (404 on read-back).

## Fix
`CreateTableEntity` now sanitizes both keys (forbidden chars → `_`) before building the entity. `SanitizeKey` allocates only when a replacement is actually needed.

## Tests
- `DataTablesKeySanitizationTests` — target-level: a configured key with `/ \ # ?` is sanitized in the captured entity (reproduced red before the fix).
- `KeyCharacterRulesTests` — Azurite characterization of the rejection that motivates it (skips if Azurite absent).

Run tests with `DOTNET_ROLL_FORWARD=Major`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)