### PR TITLE
Add release tagging and publish summary to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -167,7 +167,8 @@ jobs:
             continue
           fi
           id_lower=$(printf '%s' "$id" | tr '[:upper:]' '[:lower:]')
-          http=$(curl -sS -o "$RUNNER_TEMP/versions.json" -w '%{http_code}' \
+          http=$(curl -sS --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 10 --max-time 30 \
+            -o "$RUNNER_TEMP/versions.json" -w '%{http_code}' \
             "https://api.nuget.org/v3-flatcontainer/${id_lower}/index.json") || http="000"
           if [ "$http" = "200" ] && jq -e --arg v "$version" '.versions | index($v) != null' "$RUNNER_TEMP/versions.json" >/dev/null 2>&1; then
             skip+=("$id $version")
@@ -221,8 +222,8 @@ jobs:
           base=$(basename "$f" .nupkg)
           # Split "<PackageId>.<Version>" at the first dot that starts the version (a dot
           # followed by a digit). Package ids here are alphabetic segments, so this is safe.
-          id=$(printf '%s' "$base" | grep -oP '^.*?(?=\.\d)')
-          version=$(printf '%s' "$base" | grep -oP '^.*?\.\K\d.*')
+          id=$(printf '%s' "$base" | grep -oP '^.*?(?=\.\d)' || true)
+          version=$(printf '%s' "$base" | grep -oP '^.*?\.\K\d.*' || true)
           if [ -z "$id" ] || [ -z "$version" ]; then
             echo "WARNING: could not parse id/version from '$f' — skipping." >&2
             continue
@@ -286,7 +287,8 @@ jobs:
             continue
           fi
           id_lower=$(printf '%s' "$id" | tr '[:upper:]' '[:lower:]')
-          http=$(curl -sS -o "$RUNNER_TEMP/versions.json" -w '%{http_code}' \
+          http=$(curl -sS --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 10 --max-time 30 \
+            -o "$RUNNER_TEMP/versions.json" -w '%{http_code}' \
             "https://api.nuget.org/v3-flatcontainer/${id_lower}/index.json") || http="000"
           if [ "$http" = "200" ] && jq -e --arg v "$version" '.versions | index($v) != null' "$RUNNER_TEMP/versions.json" >/dev/null 2>&1; then
             skip+=("$id $version")

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ on:
         default: false
 
 permissions:
-  contents: read
+  contents: write  # Required to create git tags and GitHub Releases after publishing
   actions: read    # Required to download artifacts from other workflows
   id-token: write  # Required for Trusted Publishing OIDC token
 
@@ -41,8 +41,8 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         if [ -n "${{ inputs.run_id }}" ]; then
-          echo "run_id=${{ inputs.run_id }}" >> $GITHUB_OUTPUT
-          echo "Using provided run ID: ${{ inputs.run_id }}"
+          RUN_ID="${{ inputs.run_id }}"
+          echo "Using provided run ID: $RUN_ID"
         else
           # Get latest successful CI run on master
           RUN_ID=$(gh api repos/${{ github.repository }}/actions/workflows/ci.yml/runs --jq '[.workflow_runs[] | select(.conclusion == "success" and .head_branch == "master")] | .[0].id')
@@ -50,9 +50,19 @@ jobs:
             echo "ERROR: No successful CI runs found on master branch." >&2
             exit 1
           fi
-          echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
           echo "Using latest successful CI run: $RUN_ID"
         fi
+        echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+
+        # Resolve the commit these artifacts were built from, so release tags point
+        # at the right SHA (this job downloads artifacts and never checks out the repo).
+        HEAD_SHA=$(gh api repos/${{ github.repository }}/actions/runs/$RUN_ID --jq '.head_sha')
+        if [ -z "$HEAD_SHA" ] || [ "$HEAD_SHA" = "null" ]; then
+          echo "ERROR: Could not resolve head_sha for run $RUN_ID." >&2
+          exit 1
+        fi
+        echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
+        echo "Artifacts built from commit: $HEAD_SHA"
 
     - name: Download NLog.Extensions.AzureBlobStorage
       if: inputs.package == 'All' || inputs.package == 'NLog.Extensions.AzureBlobStorage'
@@ -140,8 +150,71 @@ jobs:
       working-directory: packages
       run: dotnet nuget push '*.nupkg' --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
 
+    # Auto-tag after a successful push. Packages are versioned independently, so each
+    # published package gets its own tag (<PackageId>-<Version>) and GitHub Release,
+    # pointing at the commit the artifacts were built from.
+    - name: Tag releases and create GitHub Releases
+      if: inputs.dry_run == false
+      working-directory: packages
+      env:
+        GH_TOKEN: ${{ github.token }}
+        HEAD_SHA: ${{ steps.get-run-id.outputs.head_sha }}
+        RUN_ID: ${{ steps.get-run-id.outputs.run_id }}
+        REPO: ${{ github.repository }}
+        SERVER_URL: ${{ github.server_url }}
+      run: |
+        shopt -s nullglob
+        nupkgs=(*.nupkg)
+        if [ ${#nupkgs[@]} -eq 0 ]; then
+          echo "ERROR: No .nupkg files found to tag." >&2
+          exit 1
+        fi
+
+        for f in "${nupkgs[@]}"; do
+          base=$(basename "$f" .nupkg)
+          # Split "<PackageId>.<Version>" at the first dot that starts the version (a dot
+          # followed by a digit). Package ids here are alphabetic segments, so this is safe.
+          id=$(printf '%s' "$base" | grep -oP '^.*?(?=\.\d)')
+          version=$(printf '%s' "$base" | grep -oP '^.*?\.\K\d.*')
+          if [ -z "$id" ] || [ -z "$version" ]; then
+            echo "WARNING: could not parse id/version from '$f' — skipping." >&2
+            continue
+          fi
+          tag="$id-$version"
+
+          if gh release view "$tag" --repo "$REPO" >/dev/null 2>&1; then
+            echo "Release '$tag' already exists — skipping (idempotent re-run)."
+            continue
+          fi
+
+          # Mark SemVer pre-releases (version contains a hyphen) as GitHub pre-releases.
+          prerelease_flag=""
+          case "$version" in
+            *-*) prerelease_flag="--prerelease" ;;
+          esac
+
+          notes=$(printf '%s\n' \
+            "Published \`$id\` \`$version\` to NuGet.org." \
+            "" \
+            "- Commit: $HEAD_SHA" \
+            "- CI run: $SERVER_URL/$REPO/actions/runs/$RUN_ID" \
+            "- NuGet: https://www.nuget.org/packages/$id/$version")
+
+          echo "Creating release '$tag' at $HEAD_SHA"
+          # --latest=false: with independent package versions, no single release is "latest".
+          gh release create "$tag" \
+            --repo "$REPO" \
+            --target "$HEAD_SHA" \
+            --title "$id $version" \
+            --notes "$notes" \
+            --latest=false \
+            $prerelease_flag
+        done
+
     - name: Dry run summary
       if: inputs.dry_run == true
+      env:
+        HEAD_SHA: ${{ steps.get-run-id.outputs.head_sha }}
       run: |
         echo "DRY RUN - Would push the following packages to NuGet.org:"
         if [ ! -d "packages" ]; then
@@ -154,3 +227,11 @@ jobs:
           exit 1
         fi
         echo "$PACKAGES" | while read f; do echo "  - $(basename $f)"; done
+        echo ""
+        echo "DRY RUN - Would create the following tags/releases (at commit ${HEAD_SHA}):"
+        echo "$PACKAGES" | while read f; do
+          base=$(basename "$f" .nupkg)
+          id=$(printf '%s' "$base" | grep -oP '^.*?(?=\.\d)')
+          version=$(printf '%s' "$base" | grep -oP '^.*?\.\K\d.*')
+          echo "  - $id-$version"
+        done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -148,7 +148,54 @@ jobs:
     - name: Push to NuGet
       if: inputs.dry_run == false
       working-directory: packages
-      run: dotnet nuget push '*.nupkg' --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: |
+        shopt -s nullglob
+
+        # Classify each package as "new" (version not yet on NuGet) or "skip"
+        # (version already published) BEFORE pushing. After the push everything
+        # exists on NuGet, so new-vs-skip can only be determined up front. This
+        # is what surfaces a package you meant to release but forgot to bump:
+        # it lands in "Skipped" instead of "Published".
+        new=()
+        skip=()
+        for f in *.nupkg; do
+          base=$(basename "$f" .nupkg)
+          id=$(printf '%s' "$base" | grep -oP '^.*?(?=\.\d)' || true)
+          version=$(printf '%s' "$base" | grep -oP '^.*?\.\K\d.*' || true)
+          if [ -z "$id" ] || [ -z "$version" ]; then
+            echo "WARNING: could not parse id/version from '$f'." >&2
+            continue
+          fi
+          id_lower=$(printf '%s' "$id" | tr '[:upper:]' '[:lower:]')
+          http=$(curl -sS -o "$RUNNER_TEMP/versions.json" -w '%{http_code}' \
+            "https://api.nuget.org/v3-flatcontainer/${id_lower}/index.json") || http="000"
+          if [ "$http" = "200" ] && jq -e --arg v "$version" '.versions | index($v) != null' "$RUNNER_TEMP/versions.json" >/dev/null 2>&1; then
+            skip+=("$id $version")
+          else
+            new+=("$id $version")
+          fi
+        done
+
+        # Push everything; --skip-duplicate makes already-published versions a no-op.
+        dotnet nuget push '*.nupkg' --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+        # Summary — only reached if the push above succeeded. Written to the job
+        # summary panel (Actions UI) and the step log.
+        {
+          echo "## NuGet publish summary"
+          echo ""
+          if [ ${#new[@]} -gt 0 ]; then
+            echo "### Published (new)"
+            for p in "${new[@]}"; do echo "- \`$p\`"; done
+          else
+            echo "**No new package versions were published** — every selected package's version already exists on NuGet. Did you forget to bump a \`<Version>\`?"
+          fi
+          if [ ${#skip[@]} -gt 0 ]; then
+            echo ""
+            echo "### Skipped (version already on NuGet)"
+            for p in "${skip[@]}"; do echo "- \`$p\`"; done
+          fi
+        } | tee -a "$GITHUB_STEP_SUMMARY"
 
     # Auto-tag after a successful push. Packages are versioned independently, so each
     # published package gets its own tag (<PackageId>-<Version>) and GitHub Release,
@@ -216,22 +263,52 @@ jobs:
       env:
         HEAD_SHA: ${{ steps.get-run-id.outputs.head_sha }}
       run: |
-        echo "DRY RUN - Would push the following packages to NuGet.org:"
         if [ ! -d "packages" ]; then
           echo "ERROR: packages directory does not exist. Artifact download may have failed." >&2
           exit 1
         fi
-        PACKAGES=$(find packages -name "*.nupkg" -type f)
-        if [ -z "$PACKAGES" ]; then
+        mapfile -t PKGS < <(find packages -name "*.nupkg" -type f | sort)
+        if [ ${#PKGS[@]} -eq 0 ]; then
           echo "ERROR: No .nupkg files found in packages directory. Check that artifacts were downloaded correctly." >&2
           exit 1
         fi
-        echo "$PACKAGES" | while read f; do echo "  - $(basename $f)"; done
-        echo ""
-        echo "DRY RUN - Would create the following tags/releases (at commit ${HEAD_SHA}):"
-        echo "$PACKAGES" | while read f; do
+
+        # Same new-vs-skip classification as the real publish, so a dry run reveals a
+        # forgotten <Version> bump (it shows under "Would skip") before anything ships.
+        new=()
+        skip=()
+        for f in "${PKGS[@]}"; do
           base=$(basename "$f" .nupkg)
-          id=$(printf '%s' "$base" | grep -oP '^.*?(?=\.\d)')
-          version=$(printf '%s' "$base" | grep -oP '^.*?\.\K\d.*')
-          echo "  - $id-$version"
+          id=$(printf '%s' "$base" | grep -oP '^.*?(?=\.\d)' || true)
+          version=$(printf '%s' "$base" | grep -oP '^.*?\.\K\d.*' || true)
+          if [ -z "$id" ] || [ -z "$version" ]; then
+            echo "WARNING: could not parse id/version from '$f'." >&2
+            continue
+          fi
+          id_lower=$(printf '%s' "$id" | tr '[:upper:]' '[:lower:]')
+          http=$(curl -sS -o "$RUNNER_TEMP/versions.json" -w '%{http_code}' \
+            "https://api.nuget.org/v3-flatcontainer/${id_lower}/index.json") || http="000"
+          if [ "$http" = "200" ] && jq -e --arg v "$version" '.versions | index($v) != null' "$RUNNER_TEMP/versions.json" >/dev/null 2>&1; then
+            skip+=("$id $version")
+          else
+            new+=("$id $version")
+          fi
         done
+
+        {
+          echo "## DRY RUN - NuGet publish preview"
+          echo ""
+          echo "Resolved artifacts from commit \`${HEAD_SHA}\`."
+          echo ""
+          if [ ${#new[@]} -gt 0 ]; then
+            echo "### Would publish (new) + tag"
+            for p in "${new[@]}"; do echo "- \`$p\`  →  tag \`${p// /-}\`"; done
+          else
+            echo "**Nothing new would be published** — every selected package's version already exists on NuGet. Did you forget to bump a \`<Version>\`?"
+          fi
+          if [ ${#skip[@]} -gt 0 ]; then
+            echo ""
+            echo "### Would skip (version already on NuGet)"
+            for p in "${skip[@]}"; do echo "- \`$p\`"; done
+          fi
+        } | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds release traceability and a publish summary to the manual `Publish to NuGet` workflow. No change to how packages are built or versioned — they stay independently versioned in each `.csproj`, and the build-once model (publish ships the exact artifact CI built) is preserved.

### 1. Auto-tag + GitHub Release after a successful push
- After NuGet push succeeds, create a per-package git tag `<PackageId>-<Version>` and a GitHub Release.
- Tags point at the **CI run's `head_sha`** (the commit the artifacts were built from), resolved via the Actions API — the publish job never checks out the repo.
- **Idempotent**: skips any package whose release tag already exists, so re-running publish (or publishing `All` when only one package changed) is a safe no-op.
- SemVer pre-releases (version contains `-`) are marked `--prerelease`; `--latest=false` since with independent versions no single package is "latest".
- This closes the traceability gap: current `4.7.x` packages have **no** matching git tags (tagging stopped at the old `1.x` line), so there's currently no record of which commit a published version came from.

### 2. Published-vs-skipped summary
Defaulting to "publish All" means most packages are intentionally unchanged and get silently no-op'd by `--skip-duplicate`. That hides the one mistake that matters: meaning to release a package but forgetting to bump its `<Version>`, so it skips too.

- Each package is classified **before** the push (afterwards everything exists on NuGet, so the distinction is gone) by querying the NuGet flat-container API: **Published (new)** vs **Skipped (already on NuGet)**.
- Written to the job summary panel and the step log. A forgotten bump now shows up under **Skipped**, and an all-skipped run says so loudly.
- The **dry run** runs the same classification, so the mistake is visible before anything ships.
- Exact version match via `jq index()` avoids substring false positives (e.g. `4.7.10` vs `4.7.1`).

### Notes
- Workflow token bumped to `contents: write` (needed to create tags/releases). `id-token: write` for Trusted Publishing is unchanged.
- Classification logic verified locally against live `api.nuget.org`: `4.7.1` → skip, `4.7.10`/`99.99.99` → new, no substring collisions; YAML parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)