### PR TITLE
Redesign ServiceBus/EventHub batch splitting with the SDK's native TryAdd batch API (S3)

### DIFF
--- a/src/NLog.Extensions.AzureEventHub/EventHubTarget.cs
+++ b/src/NLog.Extensions.AzureEventHub/EventHubTarget.cs
@@ -351,7 +351,7 @@ namespace NLog.Targets
 
                 try
                 {
-                    var eventDataList = CreateEventDataList(logEvents, partitionKey);
+                    var eventDataList = CreateEventDataList(logEvents);
                     return WriteEventDataAsync(eventDataList, partitionKey, cancellationToken);
                 }
                 catch (Exception ex)
@@ -370,7 +370,7 @@ namespace NLog.Targets
 
                 try
                 {
-                    var eventDataList = CreateEventDataList(partitionBucket.Value, partitionKey);
+                    var eventDataList = CreateEventDataList(partitionBucket.Value);
 
                     Task sendTask = WriteEventDataAsync(eventDataList, partitionKey, cancellationToken);
                     if (multipleTasks == null)
@@ -396,6 +396,7 @@ namespace NLog.Targets
 
             int index = 0;
             int droppedCount = 0;
+            long effectiveMaxSizeBytes = MaxBatchSizeBytes;
 
             // Build batches with the SDK's native EventDataBatch: TryAdd enforces the authoritative
             // size limit (real per-event AMQP overhead + the namespace max), so a full batch is sealed
@@ -413,6 +414,7 @@ namespace NLog.Targets
 
                     if (eventDataBatch.Count == 0)
                     {
+                        effectiveMaxSizeBytes = eventDataBatch.MaximumSizeInBytes;
                         ++droppedCount;
                         ++index;    // Skip the single oversized event so the remaining events still send
                         continue;
@@ -427,10 +429,10 @@ namespace NLog.Targets
             }
 
             if (droppedCount > 0)
-                InternalLogger.Error("AzureEventHubTarget(Name={0}): Dropped {1} logevents exceeding the max batch size of {2} bytes for EntityPath={3} with PartitionKey={4}", Name, droppedCount, MaxBatchSizeBytes, _eventHubService?.EventHubName, partitionKey);
+                InternalLogger.Error("AzureEventHubTarget(Name={0}): Dropped {1} logevents exceeding the max batch size of {2} bytes for EntityPath={3} with PartitionKey={4}", Name, droppedCount, effectiveMaxSizeBytes, _eventHubService?.EventHubName, partitionKey);
         }
 
-        private IList<EventData> CreateEventDataList(IList<LogEventInfo> logEventList, string partitionKey)
+        private IList<EventData> CreateEventDataList(IList<LogEventInfo> logEventList)
         {
             if (logEventList.Count == 0)
                 return Array.Empty<EventData>();
@@ -659,6 +661,8 @@ namespace NLog.Targets
                 }
 
                 public int Count => _batch.Count;
+
+                public long MaximumSizeInBytes => _batch.MaximumSizeInBytes;
 
                 public bool TryAddEvent(EventData eventData) => _batch.TryAdd(eventData);
 

--- a/src/NLog.Extensions.AzureEventHub/EventHubTarget.cs
+++ b/src/NLog.Extensions.AzureEventHub/EventHubTarget.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -352,8 +351,8 @@ namespace NLog.Targets
 
                 try
                 {
-                    var eventDataBatch = CreateEventDataBatch(logEvents, partitionKey, out var eventDataSize);
-                    return WriteSingleBatchAsync(eventDataBatch, partitionKey, cancellationToken);
+                    var eventDataList = CreateEventDataList(logEvents, partitionKey);
+                    return WriteEventDataAsync(eventDataList, partitionKey, cancellationToken);
                 }
                 catch (Exception ex)
                 {
@@ -371,9 +370,9 @@ namespace NLog.Targets
 
                 try
                 {
-                    var eventDataBatch = CreateEventDataBatch(partitionBucket.Value, partitionKey, out var eventDataSize);
+                    var eventDataList = CreateEventDataList(partitionBucket.Value, partitionKey);
 
-                    Task sendTask = WritePartitionBucketAsync(eventDataBatch, eventDataSize, partitionKey, cancellationToken);
+                    Task sendTask = WriteEventDataAsync(eventDataList, partitionKey, cancellationToken);
                     if (multipleTasks == null)
                         return sendTask;
 
@@ -390,126 +389,74 @@ namespace NLog.Targets
             return multipleTasks?.Count > 0 ? Task.WhenAll(multipleTasks) : Task.CompletedTask;
         }
 
-        private Task WritePartitionBucketAsync(IList<EventData> eventDataList, long eventDataSize, string partitionKey, CancellationToken cancellationToken)
+        private async Task WriteEventDataAsync(IList<EventData> eventDataList, string partitionKey, CancellationToken cancellationToken)
         {
-            int maxBatchSize = CalculateBatchSize(eventDataList, eventDataSize);
-            if (eventDataList.Count <= maxBatchSize)
-            {
-                return WriteSingleBatchAsync(eventDataList, partitionKey, cancellationToken);
-            }
-            else
-            {
-                var batchCollection = GenerateBatches(eventDataList, maxBatchSize);
-                return WriteMultipleBatchesAsync(batchCollection, partitionKey, cancellationToken);
-            }
-        }
+            if (eventDataList.Count == 0)
+                return;
 
-        private async Task WriteMultipleBatchesAsync(IEnumerable<IEnumerable<EventData>> batchCollection, string partitionKey, CancellationToken cancellationToken)
-        {
-            // Must chain the tasks together so they don't run concurrently
-            foreach (var batchItem in batchCollection)
+            int index = 0;
+            int droppedCount = 0;
+
+            // Build batches with the SDK's native EventDataBatch: TryAdd enforces the authoritative
+            // size limit (real per-event AMQP overhead + the namespace max), so a full batch is sealed
+            // and sent before the next one starts. Nothing oversized is ever sent, so there is no
+            // whole-chunk drop. Only an event that cannot fit even in an empty batch is genuinely
+            // undeliverable - it is skipped so its siblings still send, and counted for a distinct log
+            // entry below instead of being lost silently. The partition key is carried by the batch.
+            while (index < eventDataList.Count)
             {
+                var eventDataBatch = await _eventHubService.CreateBatchAsync(partitionKey, MaxBatchSizeBytes, cancellationToken).ConfigureAwait(false);
                 try
                 {
-                    await WriteSingleBatchAsync(batchItem, partitionKey, cancellationToken).ConfigureAwait(false);
+                    while (index < eventDataList.Count && eventDataBatch.TryAddEvent(eventDataList[index]))
+                        ++index;
+
+                    if (eventDataBatch.Count == 0)
+                    {
+                        ++droppedCount;
+                        ++index;    // Skip the single oversized event so the remaining events still send
+                        continue;
+                    }
+
+                    await eventDataBatch.SendAsync(cancellationToken).ConfigureAwait(false);
                 }
-                catch (EventHubsException ex)
+                finally
                 {
-                    if (ex.Reason != EventHubsException.FailureReason.MessageSizeExceeded && ex.Reason != EventHubsException.FailureReason.QuotaExceeded)
-                        throw;
-
-                    InternalLogger.Error(ex, "AzureEventHubTarget(Name={0}): Skipping failing logevents for EntityPath={1} with PartitionKey={2}", Name, ex.EventHubName, partitionKey);
+                    eventDataBatch.Dispose();
                 }
             }
+
+            if (droppedCount > 0)
+                InternalLogger.Error("AzureEventHubTarget(Name={0}): Dropped {1} logevents exceeding the max batch size of {2} bytes for EntityPath={3} with PartitionKey={4}", Name, droppedCount, MaxBatchSizeBytes, _eventHubService?.EventHubName, partitionKey);
         }
 
-        IEnumerable<IEnumerable<EventData>> GenerateBatches(IList<EventData> source, int batchSize)
-        {
-            for (int i = 0; i < source.Count; i += batchSize)
-                yield return source.Skip(i).Take(batchSize);
-        }
-
-        private Task WriteSingleBatchAsync(IEnumerable<EventData> eventDataBatch, string partitionKey, CancellationToken cancellationToken)
-        {
-            return _eventHubService.SendAsync(eventDataBatch, partitionKey, cancellationToken);
-        }
-
-        internal int CalculateBatchSize(IList<EventData> eventDataBatch, long eventDataSize)
-        {
-            if (eventDataSize < MaxBatchSizeBytes)
-                return Math.Min(eventDataBatch.Count, 100);
-
-            if (eventDataBatch.Count > 10)
-            {
-                long numberOfBatches = Math.Max(eventDataSize / MaxBatchSizeBytes, 10);
-                int batchSize = (int)Math.Max(eventDataBatch.Count / numberOfBatches - 1, 1);
-                return Math.Min(batchSize, 100);
-            }
-
-            return 1;
-        }
-
-        private IList<EventData> CreateEventDataBatch(IList<LogEventInfo> logEventList, string partitionKey, out long eventDataSize)
+        private IList<EventData> CreateEventDataList(IList<LogEventInfo> logEventList, string partitionKey)
         {
             if (logEventList.Count == 0)
-            {
-                eventDataSize = 0;
                 return Array.Empty<EventData>();
-            }
-
-            if (string.IsNullOrEmpty(partitionKey))
-                partitionKey = null;
 
             if (logEventList.Count == 1)
             {
-                var eventData = CreateEventData(partitionKey, logEventList[0], true);
-                if (eventData == null)
-                {
-                    eventDataSize = 0;
-                    return Array.Empty<EventData>();
-                }
-                eventDataSize = EstimateEventDataSize(eventData.Body.Length);
-                return new[] { eventData };
+                var eventData = CreateEventData(logEventList[0], true);
+                return eventData == null ? Array.Empty<EventData>() : new[] { eventData };
             }
 
-            int maxBodySize = 0;
-            List<EventData> eventDataBatch = new List<EventData>(logEventList.Count);
+            var eventDataList = new List<EventData>(logEventList.Count);
             for (int i = 0; i < logEventList.Count; ++i)
             {
-                var eventData = CreateEventData(partitionKey, logEventList[i], eventDataBatch.Count == 0 && i == logEventList.Count - 1);
+                var eventData = CreateEventData(logEventList[i], eventDataList.Count == 0 && i == logEventList.Count - 1);
                 if (eventData != null)
-                {
-                    int bodySize = eventData.Body.Length;
-                    if (bodySize > maxBodySize)
-                        maxBodySize = bodySize;
-                    eventDataBatch.Add(eventData);
-                }
+                    eventDataList.Add(eventData);
             }
-
-            eventDataSize = EstimateBatchSizeBytes(maxBodySize, logEventList.Count);
-            return eventDataBatch;
+            return eventDataList;
         }
 
-        internal static int EstimateEventDataSize(int eventDataSize)
-        {
-            return (eventDataSize + 128) * 3 + 128;
-        }
-
-        internal static long EstimateBatchSizeBytes(int maxBodySize, int messageCount)
-        {
-            // Use long so a large flush cannot overflow int to a negative size, which would make
-            // CalculateBatchSize treat a huge payload as a "small total" and send oversized batches.
-            // Keeping the full magnitude (instead of capping at int.MaxValue) lets the splitting
-            // heuristic scale beyond 2GB totals without saturating numberOfBatches.
-            return (long)EstimateEventDataSize(maxBodySize) * messageCount;
-        }
-
-        private EventData CreateEventData(string partitionKey, LogEventInfo logEvent, bool allowThrow)
+        private EventData CreateEventData(LogEventInfo logEvent, bool allowThrow)
         {
             try
             {
                 var eventDataBody = RenderLogEvent(Layout, logEvent) ?? string.Empty;
-                var eventData = EventHubsModelFactory.EventData(new BinaryData(EncodeToUTF8(eventDataBody)), partitionKey: partitionKey, offsetString: null);
+                var eventData = new EventData(EncodeToUTF8(eventDataBody));
 
                 var contentType = RenderLogEvent(ContentType, logEvent) ?? string.Empty;
                 if (!string.IsNullOrWhiteSpace(contentType))
@@ -610,7 +557,6 @@ namespace NLog.Targets
         private sealed class EventHubService : IEventHubService
         {
             private Azure.Messaging.EventHubs.Producer.EventHubProducerClient _client;
-            private readonly System.Collections.Concurrent.ConcurrentDictionary<string, Azure.Messaging.EventHubs.Producer.SendEventOptions> _partitionKeys = new System.Collections.Concurrent.ConcurrentDictionary<string, Azure.Messaging.EventHubs.Producer.SendEventOptions>();
 
             public string EventHubName { get; private set; }
 
@@ -667,25 +613,58 @@ namespace NLog.Targets
                 return _client?.CloseAsync() ?? Task.CompletedTask;
             }
 
-            public Task SendAsync(IEnumerable<EventData> eventDataBatch, string partitionKey, CancellationToken cancellationToken)
+            public async Task<IEventDataBatch> CreateBatchAsync(string partitionKey, int maxBatchSizeBytes, CancellationToken cancellationToken)
             {
                 if (_client == null)
                     throw new InvalidOperationException("EventHubClient has not been initialized");
 
-                Azure.Messaging.EventHubs.Producer.SendEventOptions sendEventOptions = null;
+                var options = new Azure.Messaging.EventHubs.Producer.CreateBatchOptions();
                 if (!string.IsNullOrEmpty(partitionKey))
+                    options.PartitionKey = partitionKey;
+
+                Azure.Messaging.EventHubs.Producer.EventDataBatch batch;
+                if (maxBatchSizeBytes > 0)
                 {
-                    if (!_partitionKeys.TryGetValue(partitionKey, out sendEventOptions))
+                    options.MaximumSizeInBytes = maxBatchSizeBytes;
+                    try
                     {
-                        sendEventOptions = new Azure.Messaging.EventHubs.Producer.SendEventOptions() { PartitionKey = partitionKey };
-                        _partitionKeys.TryAdd(partitionKey, sendEventOptions);
+                        batch = await _client.CreateBatchAsync(options, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (ArgumentOutOfRangeException)
+                    {
+                        // Requested cap exceeds the namespace's negotiated maximum - let the SDK use its max.
+                        var fallback = new Azure.Messaging.EventHubs.Producer.CreateBatchOptions();
+                        if (!string.IsNullOrEmpty(partitionKey))
+                            fallback.PartitionKey = partitionKey;
+                        batch = await _client.CreateBatchAsync(fallback, cancellationToken).ConfigureAwait(false);
                     }
                 }
-
-                if (sendEventOptions != null)
-                    return _client.SendAsync(eventDataBatch, sendEventOptions, cancellationToken);
                 else
-                    return _client.SendAsync(eventDataBatch, cancellationToken);
+                {
+                    batch = await _client.CreateBatchAsync(options, cancellationToken).ConfigureAwait(false);
+                }
+
+                return new EventDataBatchWrapper(_client, batch);
+            }
+
+            private sealed class EventDataBatchWrapper : IEventDataBatch
+            {
+                private readonly Azure.Messaging.EventHubs.Producer.EventHubProducerClient _client;
+                private readonly Azure.Messaging.EventHubs.Producer.EventDataBatch _batch;
+
+                public EventDataBatchWrapper(Azure.Messaging.EventHubs.Producer.EventHubProducerClient client, Azure.Messaging.EventHubs.Producer.EventDataBatch batch)
+                {
+                    _client = client;
+                    _batch = batch;
+                }
+
+                public int Count => _batch.Count;
+
+                public bool TryAddEvent(EventData eventData) => _batch.TryAdd(eventData);
+
+                public Task SendAsync(CancellationToken cancellationToken) => _client.SendAsync(_batch, cancellationToken);
+
+                public void Dispose() => _batch.Dispose();
             }
         }
     }

--- a/src/NLog.Extensions.AzureEventHub/IEventHubService.cs
+++ b/src/NLog.Extensions.AzureEventHub/IEventHubService.cs
@@ -35,5 +35,8 @@ namespace NLog.Extensions.AzureStorage
 
         /// <summary>Sends the events accumulated in this batch.</summary>
         Task SendAsync(CancellationToken cancellationToken);
+
+        /// <summary>The authoritative maximum batch size in bytes enforced by the SDK (the negotiated namespace maximum when no explicit cap was requested).</summary>
+        long MaximumSizeInBytes { get; }
     }
 }

--- a/src/NLog.Extensions.AzureEventHub/IEventHubService.cs
+++ b/src/NLog.Extensions.AzureEventHub/IEventHubService.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs;
@@ -11,6 +11,29 @@ namespace NLog.Extensions.AzureStorage
         string EventHubName { get; }
         void Connect(string connectionString, string eventHubName, string serviceUri, string tenantIdentity, string managedIdentityResourceId, string managedIdentityClientId, string sharedAccessSignature, string storageAccountName, string storageAccountAccessKey, string clientAuthId, string clientAuthSecret, string eventProducerIdentifier, bool useWebSockets, string endPointAddress, ProxySettings proxySettings);
         Task CloseAsync();
-        Task SendAsync(IEnumerable<EventData> eventDataBatch, string partitionKey, CancellationToken cancellationToken);
+        Task<IEventDataBatch> CreateBatchAsync(string partitionKey, int maxBatchSizeBytes, CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Thin abstraction over <c>EventDataBatch</c> so the size-aware splitting in
+    /// <see cref="NLog.Targets.EventHubTarget"/> is enforced by the SDK's authoritative
+    /// <c>TryAdd</c> overflow check, while still being unit-testable through a fake. The
+    /// batch carries the partition key (set via <c>CreateBatchOptions.PartitionKey</c>).
+    /// </summary>
+    internal interface IEventDataBatch : IDisposable
+    {
+        /// <summary>Number of events accepted into the batch so far.</summary>
+        int Count { get; }
+
+        /// <summary>
+        /// Attempts to add an event to the batch. Returns <see langword="false"/> when the
+        /// event does not fit: either the batch is full (seal and send it, then retry on a
+        /// fresh batch) or - when the batch is empty - the single event is larger than the
+        /// maximum allowed size and can never be delivered.
+        /// </summary>
+        bool TryAddEvent(EventData eventData);
+
+        /// <summary>Sends the events accumulated in this batch.</summary>
+        Task SendAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/NLog.Extensions.AzureServiceBus/ICloudServiceBus.cs
+++ b/src/NLog.Extensions.AzureServiceBus/ICloudServiceBus.cs
@@ -25,6 +25,9 @@ namespace NLog.Extensions.AzureStorage
         /// <summary>Number of messages accepted into the batch so far.</summary>
         int Count { get; }
 
+        /// <summary>The authoritative maximum batch size in bytes enforced by the SDK (the negotiated namespace maximum when no explicit cap was requested).</summary>
+        long MaximumSizeInBytes { get; }
+
         /// <summary>
         /// Attempts to add a message to the batch. Returns <see langword="false"/> when the
         /// message does not fit: either the batch is full (seal and send it, then retry on a

--- a/src/NLog.Extensions.AzureServiceBus/ICloudServiceBus.cs
+++ b/src/NLog.Extensions.AzureServiceBus/ICloudServiceBus.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
@@ -12,7 +11,29 @@ namespace NLog.Extensions.AzureStorage
         string EntityPath { get; }
         TimeSpan? DefaultTimeToLive { get; }
         void Connect(string connectionString, string queueOrTopicName, string serviceUri, string tenantIdentity, string managedIdentityResourceId, string managedIdentityClientId, string sharedAccessSignature, string storageAccountName, string storageAccountAccessKey, string clientAuthId, string clientAuthSecret, string eventProducerIdentifier, bool useWebSockets, string endPointAddress, TimeSpan? timeToLive, ProxySettings proxySettings);
-        Task SendAsync(IEnumerable<ServiceBusMessage> messages, CancellationToken cancellationToken);
+        Task<IServiceBusMessageBatch> CreateMessageBatchAsync(int maxBatchSizeBytes, CancellationToken cancellationToken);
         Task CloseAsync();
+    }
+
+    /// <summary>
+    /// Thin abstraction over <c>ServiceBusMessageBatch</c> so the size-aware splitting in
+    /// <see cref="NLog.Targets.ServiceBusTarget"/> is enforced by the SDK's authoritative
+    /// <c>TryAddMessage</c> overflow check, while still being unit-testable through a fake.
+    /// </summary>
+    internal interface IServiceBusMessageBatch : IDisposable
+    {
+        /// <summary>Number of messages accepted into the batch so far.</summary>
+        int Count { get; }
+
+        /// <summary>
+        /// Attempts to add a message to the batch. Returns <see langword="false"/> when the
+        /// message does not fit: either the batch is full (seal and send it, then retry on a
+        /// fresh batch) or - when the batch is empty - the single message is larger than the
+        /// maximum allowed size and can never be delivered.
+        /// </summary>
+        bool TryAddMessage(ServiceBusMessage message);
+
+        /// <summary>Sends the messages accumulated in this batch.</summary>
+        Task SendAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/NLog.Extensions.AzureServiceBus/ServiceBusTarget.cs
+++ b/src/NLog.Extensions.AzureServiceBus/ServiceBusTarget.cs
@@ -459,6 +459,7 @@ namespace NLog.Targets
 
             int index = 0;
             int droppedCount = 0;
+            long effectiveMaxSizeBytes = MaxBatchSizeBytes;     // Captured from the batch on drop, so the log reports the SDK's real max (authoritative when MaxBatchSizeBytes <= 0)
 
             // Build batches with the SDK's native ServiceBusMessageBatch: TryAddMessage enforces the
             // authoritative size limit (real per-message AMQP overhead + the namespace max), so a full
@@ -476,6 +477,7 @@ namespace NLog.Targets
 
                     if (messageBatch.Count == 0)
                     {
+                        effectiveMaxSizeBytes = messageBatch.MaximumSizeInBytes;
                         ++droppedCount;
                         ++index;    // Skip the single oversized message so the remaining messages still send
                         continue;
@@ -490,7 +492,7 @@ namespace NLog.Targets
             }
 
             if (droppedCount > 0)
-                InternalLogger.Error("AzureServiceBusTarget(Name={0}): Dropped {1} logevents exceeding the max batch size of {2} bytes for EntityPath={3} with PartitionKey={4}", Name, droppedCount, MaxBatchSizeBytes, _cloudServiceBus?.EntityPath, partitionKey);
+                InternalLogger.Error("AzureServiceBusTarget(Name={0}): Dropped {1} logevents exceeding the max batch size of {2} bytes for EntityPath={3} with PartitionKey={4}", Name, droppedCount, effectiveMaxSizeBytes, _cloudServiceBus?.EntityPath, partitionKey);
         }
 
         private IList<ServiceBusMessage> CreateMessages(IList<LogEventInfo> logEventList, string partitionKey)
@@ -734,6 +736,8 @@ namespace NLog.Targets
                 }
 
                 public int Count => _batch.Count;
+
+                public long MaximumSizeInBytes => _batch.MaxSizeInBytes;
 
                 public bool TryAddMessage(ServiceBusMessage message) => _batch.TryAddMessage(message);
 

--- a/src/NLog.Extensions.AzureServiceBus/ServiceBusTarget.cs
+++ b/src/NLog.Extensions.AzureServiceBus/ServiceBusTarget.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -415,8 +414,8 @@ namespace NLog.Targets
 
                 try
                 {
-                    var messageBatch = CreateMessageBatch(logEvents, partitionKey, out var messageBatchSize);
-                    return WriteSingleBatchAsync(messageBatch, cancellationToken);
+                    var messages = CreateMessages(logEvents, partitionKey);
+                    return WriteMessagesAsync(messages, partitionKey, cancellationToken);
                 }
                 catch (Exception ex)
                 {
@@ -434,9 +433,9 @@ namespace NLog.Targets
 
                 try
                 {
-                    var messageBatch = CreateMessageBatch(partitionBucket.Value, partitionBucket.Key, out var messageBatchSize);
+                    var messages = CreateMessages(partitionBucket.Value, partitionKey);
 
-                    Task sendTask = WritePartitionBucketAsync(messageBatch, messageBatchSize, cancellationToken);
+                    Task sendTask = WriteMessagesAsync(messages, partitionKey, cancellationToken);
                     if (multipleTasks == null)
                         return sendTask;
 
@@ -453,115 +452,66 @@ namespace NLog.Targets
             return multipleTasks?.Count > 0 ? Task.WhenAll(multipleTasks) : Task.CompletedTask;
         }
 
-        private Task WritePartitionBucketAsync(IList<ServiceBusMessage> messageBatch, long messageBatchSize, CancellationToken cancellationToken)
+        private async Task WriteMessagesAsync(IList<ServiceBusMessage> messages, string partitionKey, CancellationToken cancellationToken)
         {
-            int maxBatchSize = CalculateBatchSize(messageBatch, messageBatchSize);
-            if (messageBatch.Count <= maxBatchSize)
-            {
-                return WriteSingleBatchAsync(messageBatch, cancellationToken);
-            }
-            else
-            {
-                var batchCollection = GenerateBatches(messageBatch, maxBatchSize);
-                return WriteMultipleBatchesAsync(batchCollection, cancellationToken);
-            }
-        }
+            if (messages.Count == 0)
+                return;
 
-        private async Task WriteMultipleBatchesAsync(IEnumerable<IEnumerable<ServiceBusMessage>> batchCollection, CancellationToken cancellationToken)
-        {
-            // Must chain the tasks together so they don't run concurrently
-            foreach (var batchItem in batchCollection)
+            int index = 0;
+            int droppedCount = 0;
+
+            // Build batches with the SDK's native ServiceBusMessageBatch: TryAddMessage enforces the
+            // authoritative size limit (real per-message AMQP overhead + the namespace max), so a full
+            // batch is sealed and sent before the next one starts. Nothing oversized is ever sent, so
+            // there is no whole-chunk drop. Only a message that cannot fit even in an empty batch is
+            // genuinely undeliverable - it is skipped so its siblings still send, and counted for a
+            // distinct log entry below instead of being lost silently.
+            while (index < messages.Count)
             {
+                var messageBatch = await _cloudServiceBus.CreateMessageBatchAsync(MaxBatchSizeBytes, cancellationToken).ConfigureAwait(false);
                 try
                 {
-                    await WriteSingleBatchAsync(batchItem, cancellationToken).ConfigureAwait(false);
+                    while (index < messages.Count && messageBatch.TryAddMessage(messages[index]))
+                        ++index;
+
+                    if (messageBatch.Count == 0)
+                    {
+                        ++droppedCount;
+                        ++index;    // Skip the single oversized message so the remaining messages still send
+                        continue;
+                    }
+
+                    await messageBatch.SendAsync(cancellationToken).ConfigureAwait(false);
                 }
-                catch (ServiceBusException ex)
+                finally
                 {
-                    if (ex.Reason != ServiceBusFailureReason.MessageSizeExceeded && ex.Reason != ServiceBusFailureReason.QuotaExceeded)
-                        throw;
-
-                    InternalLogger.Error(ex, "AzureServiceBusTarget(Name={0}): Skipping failing logevents for EntityPath={1}", Name, ex.EntityPath);
+                    messageBatch.Dispose();
                 }
             }
+
+            if (droppedCount > 0)
+                InternalLogger.Error("AzureServiceBusTarget(Name={0}): Dropped {1} logevents exceeding the max batch size of {2} bytes for EntityPath={3} with PartitionKey={4}", Name, droppedCount, MaxBatchSizeBytes, _cloudServiceBus?.EntityPath, partitionKey);
         }
 
-        IEnumerable<IEnumerable<ServiceBusMessage>> GenerateBatches(IList<ServiceBusMessage> source, int batchSize)
-        {
-            for (int i = 0; i < source.Count; i += batchSize)
-                yield return source.Skip(i).Take(batchSize);
-        }
-
-        private Task WriteSingleBatchAsync(IEnumerable<ServiceBusMessage> messageBatch, CancellationToken cancellationToken)
-        {
-            return _cloudServiceBus.SendAsync(messageBatch, cancellationToken);
-        }
-
-        internal int CalculateBatchSize(IList<ServiceBusMessage> messageBatch, long messageBatchSize)
-        {
-            if (messageBatchSize < MaxBatchSizeBytes)
-                return Math.Min(messageBatch.Count, 100);
-
-            if (messageBatch.Count > 10)
-            {
-                long numberOfBatches = Math.Max(messageBatchSize / MaxBatchSizeBytes, 10);
-                int batchSize = (int)Math.Max(messageBatch.Count / numberOfBatches - 1, 1);
-                return Math.Min(batchSize, 100);
-            }
-
-            return 1;
-        }
-
-        private IList<ServiceBusMessage> CreateMessageBatch(IList<LogEventInfo> logEventList, string partitionKey, out long messageBatchSize)
+        private IList<ServiceBusMessage> CreateMessages(IList<LogEventInfo> logEventList, string partitionKey)
         {
             if (logEventList.Count == 0)
-            {
-                messageBatchSize = 0;
                 return Array.Empty<ServiceBusMessage>();
-            }
 
             if (logEventList.Count == 1)
             {
                 var messageData = CreateMessageData(logEventList[0], partitionKey, true);
-                if (messageData == null)
-                {
-                    messageBatchSize = 0;
-                    return Array.Empty<ServiceBusMessage>();
-                }
-                messageBatchSize = EstimateEventDataSize(messageData.Body.ToMemory().Length);
-                return new[] { messageData };
+                return messageData == null ? Array.Empty<ServiceBusMessage>() : new[] { messageData };
             }
 
-            int maxBodySize = 0;
-            List<ServiceBusMessage> messageBatch = new List<ServiceBusMessage>(logEventList.Count);
+            var messageBatch = new List<ServiceBusMessage>(logEventList.Count);
             for (int i = 0; i < logEventList.Count; ++i)
             {
                 var messageData = CreateMessageData(logEventList[i], partitionKey, messageBatch.Count == 0 && i == logEventList.Count - 1);
                 if (messageData != null)
-                {
-                    int bodySize = messageData.Body.ToMemory().Length;
-                    if (bodySize > maxBodySize)
-                        maxBodySize = bodySize;
                     messageBatch.Add(messageData);
-                }
             }
-
-            messageBatchSize = EstimateBatchSizeBytes(maxBodySize, logEventList.Count);
             return messageBatch;
-        }
-
-        internal static int EstimateEventDataSize(int eventDataSize)
-        {
-            return (eventDataSize + 128) * 3 + 128;
-        }
-
-        internal static long EstimateBatchSizeBytes(int maxBodySize, int messageCount)
-        {
-            // Use long so a large flush cannot overflow int to a negative size, which would make
-            // CalculateBatchSize treat a huge payload as a "small total" and send oversized batches.
-            // Keeping the full magnitude (instead of capping at int.MaxValue) lets the splitting
-            // heuristic scale beyond 2GB totals without saturating numberOfBatches.
-            return (long)EstimateEventDataSize(maxBodySize) * messageCount;
         }
 
         private ServiceBusMessage CreateMessageData(LogEventInfo logEvent, string partitionKey, bool allowThrow)
@@ -746,12 +696,50 @@ namespace NLog.Targets
                 await (_client?.DisposeAsync() ?? new ValueTask(Task.CompletedTask));
             }
 
-            public Task SendAsync(IEnumerable<ServiceBusMessage> messages, CancellationToken cancellationToken)
+            public async Task<IServiceBusMessageBatch> CreateMessageBatchAsync(int maxBatchSizeBytes, CancellationToken cancellationToken)
             {
-                if (_client == null)
+                if (_sender == null)
                     throw new InvalidOperationException("ServiceBusClient has not been initialized");
 
-                return _sender.SendMessagesAsync(messages, cancellationToken);
+                ServiceBusMessageBatch batch;
+                if (maxBatchSizeBytes > 0)
+                {
+                    try
+                    {
+                        batch = await _sender.CreateMessageBatchAsync(new CreateMessageBatchOptions { MaxSizeInBytes = maxBatchSizeBytes }, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (ArgumentOutOfRangeException)
+                    {
+                        // Requested cap exceeds the namespace's negotiated maximum - let the SDK use its max.
+                        batch = await _sender.CreateMessageBatchAsync(cancellationToken).ConfigureAwait(false);
+                    }
+                }
+                else
+                {
+                    batch = await _sender.CreateMessageBatchAsync(cancellationToken).ConfigureAwait(false);
+                }
+
+                return new ServiceBusMessageBatchWrapper(_sender, batch);
+            }
+
+            private sealed class ServiceBusMessageBatchWrapper : IServiceBusMessageBatch
+            {
+                private readonly ServiceBusSender _sender;
+                private readonly ServiceBusMessageBatch _batch;
+
+                public ServiceBusMessageBatchWrapper(ServiceBusSender sender, ServiceBusMessageBatch batch)
+                {
+                    _sender = sender;
+                    _batch = batch;
+                }
+
+                public int Count => _batch.Count;
+
+                public bool TryAddMessage(ServiceBusMessage message) => _batch.TryAddMessage(message);
+
+                public Task SendAsync(CancellationToken cancellationToken) => _sender.SendMessagesAsync(_batch, cancellationToken);
+
+                public void Dispose() => _batch.Dispose();
             }
         }
     }

--- a/test/NLog.Extensions.AzureEventHub.Tests/EventHubBatchSizeTests.cs
+++ b/test/NLog.Extensions.AzureEventHub.Tests/EventHubBatchSizeTests.cs
@@ -1,44 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
 using Azure.Messaging.EventHubs;
+using NLog.Common;
+using NLog.Config;
 using NLog.Targets;
 using Xunit;
 
 namespace NLog.Extensions.AzureEventHub.Test
 {
-    // #5: CreateEventDataBatch estimates the batch byte-size as EstimateEventDataSize(maxBody) * count
-    // using int arithmetic. For a large flush this overflows to a NEGATIVE value, which makes
-    // CalculateBatchSize take the "small total" branch (up to 100 events/batch) instead of splitting,
-    // producing multi-MB batches that exceed the Event Hub limit and are rejected.
+    // S3 (full): the target now splits a flush into batches with the SDK's native EventDataBatch +
+    // TryAdd (driven here by EventHubServiceMock.FakeEventDataBatch, which caps a batch at
+    // MaxBatchSizeBytes). These tests prove:
+    //   1. a payload just over the limit splits into ~2 batches, not the >=10 the old count-based
+    //      heuristic produced;
+    //   2. a large flush is delivered in full, with every batch within the size cap and a sane
+    //      batch count (no int-overflow, no oversized batch);
+    //   3. an oversize event is NOT silently swallowed as a whole chunk: its siblings are still
+    //      sent, only the single undeliverable event is dropped, and that drop is logged.
     public class EventHubBatchSizeTests
     {
-        private const int MaxBatch = 1024 * 1024; // EventHubTarget.MaxBatchSizeBytes default
-
-        [Fact]
-        public void LargeFlushSizeEstimateDoesNotOverflow()
+        private static EventHubServiceMock CreateTarget(int maxBatchSizeBytes, out LogFactory logFactory, out Logger logger)
         {
-            const int maxBodyBytes = 200_000;
-            const int count = 20_000;
+            logFactory = new LogFactory();
+            var logConfig = new LoggingConfiguration(logFactory);
+            var eventHubServiceMock = new EventHubServiceMock();
+            var target = new EventHubTarget(eventHubServiceMock)
+            {
+                ConnectionString = "LocalEventHub",
+                EventHubName = "${shortdate}",
+                Layout = "${message}",
+                MaxBatchSizeBytes = maxBatchSizeBytes,
+                BatchSize = 10000,                                              // deliver the flush in one WriteAsyncTask call
+                OverflowAction = Targets.Wrappers.AsyncTargetWrapperOverflowAction.Grow,
+                TaskDelayMilliseconds = 1,
+            };
+            logConfig.AddRuleForAllLevels(target);
+            logFactory.Configuration = logConfig;
+            logger = logFactory.GetLogger(nameof(EventHubBatchSizeTests));
+            return eventHubServiceMock;
+        }
 
-            long trueTotal = (long)EventHubTarget.EstimateEventDataSize(maxBodyBytes) * count;
-            Assert.True(trueTotal > MaxBatch, "sanity: this flush genuinely needs many batches");
-
-            long estimate = EventHubTarget.EstimateBatchSizeBytes(maxBodyBytes, count);
-            Assert.True(estimate > 0, $"size estimate overflowed to {estimate} (negative) for a large flush");
-            Assert.Equal(trueTotal, estimate); // long arithmetic must keep the full magnitude (no overflow, no cap)
+        private static List<List<EventData>> SnapshotBatches(EventHubServiceMock mock)
+        {
+            lock (mock.EventDataSent)
+                return mock.BatchesSent.Select(b => new List<EventData>(b.Value)).ToList();
         }
 
         [Fact]
-        public void LargeFlushIsSplitIntoSmallBatches()
+        public void PayloadJustOverLimit_SplitsIntoFewBatches_NotMany()
         {
-            const int maxBodyBytes = 200_000;
-            const int count = 20_000;
+            const int cap = 1000;
+            var mock = CreateTarget(cap, out var logFactory, out var logger);
 
-            var target = new EventHubTarget { MaxBatchSizeBytes = MaxBatch };
-            var events = new EventData[count]; // CalculateBatchSize only reads .Count
-            long estimate = EventHubTarget.EstimateBatchSizeBytes(maxBodyBytes, count);
+            // 5 x 300 bytes = 1500 bytes, just over a 1000-byte cap -> needs 2 batches (3 + 2).
+            for (int i = 0; i < 5; ++i)
+                logger.Info(new string('a', 300));
+            logFactory.Flush();
 
-            int perBatch = target.CalculateBatchSize(events, estimate);
+            var batches = SnapshotBatches(mock);
+            int totalSent = batches.Sum(b => b.Count);
 
-            Assert.True(perBatch < 100, $"a {count}-event flush was placed into batches of {perBatch} (the overflow took the 'small total' path -> oversized batches)");
+            Assert.Equal(5, totalSent);                                        // nothing lost
+            Assert.True(batches.Count >= 2 && batches.Count <= 3,
+                $"expected ~2 batches for a payload just over the limit, got {batches.Count} (old count-based math produced >=10)");
+            Assert.All(batches, b => Assert.True(BodyBytes(b) <= cap, $"batch of {BodyBytes(b)} bytes exceeds the {cap}-byte cap"));
+        }
+
+        [Fact]
+        public void LargeFlush_DeliveredInFull_WithSaneBatchCountAndNoOversizedBatch()
+        {
+            const int cap = 4096;
+            const int count = 1000;
+            const int bodyBytes = 500;                                         // 8 events per 4096-byte batch
+            var mock = CreateTarget(cap, out var logFactory, out var logger);
+
+            for (int i = 0; i < count; ++i)
+                logger.Info(new string('x', bodyBytes));
+            logFactory.Flush();
+
+            var batches = SnapshotBatches(mock);
+            int totalSent = batches.Sum(b => b.Count);
+
+            Assert.Equal(count, totalSent);                                    // no overflow, no whole-chunk drop
+            Assert.All(batches, b => Assert.True(BodyBytes(b) <= cap, $"batch of {BodyBytes(b)} bytes exceeds the {cap}-byte cap"));
+            // ~125 batches expected. Old math over-split to one-event-per-batch (~1000).
+            Assert.True(batches.Count > 1 && batches.Count <= count / 4,
+                $"expected a sane batch count near {count * bodyBytes / cap}, got {batches.Count}");
+        }
+
+        [Fact]
+        public void OversizeEvent_IsDroppedAndLogged_SiblingsStillSent()
+        {
+            const int cap = 1000;
+            var mock = CreateTarget(cap, out var logFactory, out var logger);
+
+            var originalWriter = InternalLogger.LogWriter;
+            var originalLevel = InternalLogger.LogLevel;
+            var capture = new StringWriter();
+            InternalLogger.LogWriter = capture;
+            InternalLogger.LogLevel = LogLevel.Error;
+            try
+            {
+                logger.Info(new string('a', 300));
+                logger.Info(new string('b', 300));
+                logger.Info(new string('g', 5000));     // larger than the 1000-byte cap -> undeliverable on its own
+                logger.Info(new string('c', 300));
+                logger.Info(new string('d', 300));
+                logFactory.Flush();
+            }
+            finally
+            {
+                InternalLogger.LogWriter = originalWriter;
+                InternalLogger.LogLevel = originalLevel;
+            }
+
+            var batches = SnapshotBatches(mock);
+            var delivered = batches.SelectMany(b => b).Select(e => Encoding.UTF8.GetString(e.Body.ToArray())).ToList();
+
+            Assert.Equal(4, delivered.Count);                                  // the 4 siblings still send
+            Assert.DoesNotContain(delivered, body => body.Length == 5000);     // the oversize one is gone
+            Assert.All(delivered, body => Assert.Equal(300, body.Length));
+            Assert.All(batches, b => Assert.True(BodyBytes(b) <= cap));
+            // Dropped distinctly, not lost silently and not swallowed as a whole chunk.
+            Assert.Contains("Dropped 1 logevents", capture.ToString());
+        }
+
+        private static int BodyBytes(IEnumerable<EventData> batch)
+        {
+            return batch.Sum(e => e.Body.Length);
         }
     }
 }

--- a/test/NLog.Extensions.AzureEventHub.Tests/EventHubBatchSizeTests.cs
+++ b/test/NLog.Extensions.AzureEventHub.Tests/EventHubBatchSizeTests.cs
@@ -20,6 +20,10 @@ namespace NLog.Extensions.AzureEventHub.Test
     //      batch count (no int-overflow, no oversized batch);
     //   3. an oversize event is NOT silently swallowed as a whole chunk: its siblings are still
     //      sent, only the single undeliverable event is dropped, and that drop is logged.
+    [CollectionDefinition("InternalLogger isolation", DisableParallelization = true)]
+    public class InternalLoggerIsolationCollection { }
+
+    [Collection("InternalLogger isolation")]
     public class EventHubBatchSizeTests
     {
         private static EventHubServiceMock CreateTarget(int maxBatchSizeBytes, out LogFactory logFactory, out Logger logger)

--- a/test/NLog.Extensions.AzureEventHub.Tests/EventHubServiceMock.cs
+++ b/test/NLog.Extensions.AzureEventHub.Tests/EventHubServiceMock.cs
@@ -92,6 +92,8 @@ namespace NLog.Extensions.AzureEventHub.Test
 
             public int Count => _events.Count;
 
+            public long MaximumSizeInBytes => _maxSizeBytes;
+
             public bool TryAddEvent(EventData eventData)
             {
                 int eventSize = eventData.Body.Length;

--- a/test/NLog.Extensions.AzureEventHub.Tests/EventHubServiceMock.cs
+++ b/test/NLog.Extensions.AzureEventHub.Tests/EventHubServiceMock.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Messaging.EventHubs;
+using Azure.Messaging.EventHubs;
 using NLog.Extensions.AzureBlobStorage;
 using NLog.Extensions.AzureStorage;
 using System;
@@ -11,9 +11,10 @@ namespace NLog.Extensions.AzureEventHub.Test
 {
     class EventHubServiceMock : IEventHubService
     {
-        private readonly Random _random = new Random();
-
+        // All events that were actually sent, aggregated per partition key (in send order).
         public Dictionary<string, List<EventData>> EventDataSent { get; } = new Dictionary<string, List<EventData>>();
+        // One entry per batch that was actually sent (partition key + the events it carried).
+        public List<KeyValuePair<string, List<EventData>>> BatchesSent { get; } = new List<KeyValuePair<string, List<EventData>>>();
         public string ConnectionString { get; private set; }
         public string EventHubName { get; private set; }
 
@@ -21,7 +22,10 @@ namespace NLog.Extensions.AzureEventHub.Test
         {
             await Task.Delay(1).ConfigureAwait(false);
             lock (EventDataSent)
+            {
                 EventDataSent.Clear();
+                BatchesSent.Clear();
+            }
         }
 
         public void Connect(string connectionString, string eventHubName, string serviceUri, string tenantIdentity, string managedIdentityResourceId, string managedIdentityClientId, string sharedAccessSignature, string storageAccountName, string storageAccountAccessKey, string clientAuthId, string clientAuthSecret, string eventProducerIdentifier, bool useWebSockets, string endPointAddress, ProxySettings proxySettings)
@@ -30,21 +34,26 @@ namespace NLog.Extensions.AzureEventHub.Test
             EventHubName = eventHubName;
         }
 
-        public Task SendAsync(IEnumerable<EventData> eventDataBatch, string partitionKey, CancellationToken cancellationToken)
+        public Task<IEventDataBatch> CreateBatchAsync(string partitionKey, int maxBatchSizeBytes, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(ConnectionString))
                 throw new InvalidOperationException("EventHubService not connected");
 
-            return Task.Delay(_random.Next(5, 10), cancellationToken).ContinueWith(t =>
+            int cap = maxBatchSizeBytes > 0 ? maxBatchSizeBytes : int.MaxValue;
+            return Task.FromResult<IEventDataBatch>(new FakeEventDataBatch(this, partitionKey ?? string.Empty, cap));
+        }
+
+        private void RecordBatch(string partitionKey, List<EventData> events)
+        {
+            lock (EventDataSent)
             {
-                lock (EventDataSent)
-                {
-                    if (EventDataSent.TryGetValue(partitionKey, out var existingBatch))
-                        existingBatch.AddRange(eventDataBatch);
-                    else
-                        EventDataSent[partitionKey] = new List<EventData>(eventDataBatch);
-                }
-            }, cancellationToken);
+                if (EventDataSent.TryGetValue(partitionKey, out var existingBatch))
+                    existingBatch.AddRange(events);
+                else
+                    EventDataSent[partitionKey] = new List<EventData>(events);
+
+                BatchesSent.Add(new KeyValuePair<string, List<EventData>>(partitionKey, events));
+            }
         }
 
         public string PeekLastSent(string partitionKey)
@@ -61,6 +70,53 @@ namespace NLog.Extensions.AzureEventHub.Test
             }
 
             return null;
+        }
+
+        // Mimics EventDataBatch: TryAddEvent caps the batch at maxSizeBytes (measured by the event
+        // body length), so a full batch must be sealed/sent before the next one starts, and a single
+        // event larger than the cap can never be added to an empty batch.
+        private sealed class FakeEventDataBatch : IEventDataBatch
+        {
+            private readonly EventHubServiceMock _owner;
+            private readonly string _partitionKey;
+            private readonly int _maxSizeBytes;
+            private readonly List<EventData> _events = new List<EventData>();
+            private long _sizeBytes;
+
+            public FakeEventDataBatch(EventHubServiceMock owner, string partitionKey, int maxSizeBytes)
+            {
+                _owner = owner;
+                _partitionKey = partitionKey;
+                _maxSizeBytes = maxSizeBytes;
+            }
+
+            public int Count => _events.Count;
+
+            public bool TryAddEvent(EventData eventData)
+            {
+                int eventSize = eventData.Body.Length;
+                long newSize = _sizeBytes + eventSize;
+                if (_events.Count > 0 && newSize > _maxSizeBytes)
+                    return false;   // batch full -> caller seals and sends, then retries on a fresh batch
+                if (_events.Count == 0 && eventSize > _maxSizeBytes)
+                    return false;   // single event too large to ever fit
+                _sizeBytes = newSize;
+                _events.Add(eventData);
+                return true;
+            }
+
+            public Task SendAsync(CancellationToken cancellationToken)
+            {
+                var snapshot = new List<EventData>(_events);
+                return Task.Delay(3, cancellationToken).ContinueWith(t =>
+                {
+                    _owner.RecordBatch(_partitionKey, snapshot);
+                }, cancellationToken);
+            }
+
+            public void Dispose()
+            {
+            }
         }
     }
 }

--- a/test/NLog.Extensions.AzureServiceBus.Tests/ServiceBusBatchSizeTests.cs
+++ b/test/NLog.Extensions.AzureServiceBus.Tests/ServiceBusBatchSizeTests.cs
@@ -1,47 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
 using Azure.Messaging.ServiceBus;
+using NLog.Common;
+using NLog.Config;
 using NLog.Targets;
 using Xunit;
 
 namespace NLog.Extensions.AzureServiceBus.Test
 {
-    // #5: CreateMessageBatch estimates the batch byte-size as EstimateEventDataSize(maxBody) * count
-    // using int arithmetic. For a large flush this overflows to a NEGATIVE value, which makes
-    // CalculateBatchSize take the "small total" branch (up to 100 messages/batch) instead of
-    // splitting. The result is multi-MB batches that exceed the Service Bus limit and are rejected.
+    // S3 (full): the target now splits a flush into batches with the SDK's native
+    // ServiceBusMessageBatch + TryAddMessage (driven here by ServiceBusMock.FakeMessageBatch,
+    // which caps a batch at MaxBatchSizeBytes). These tests prove:
+    //   1. a payload just over the limit splits into ~2 batches, not the >=10 the old
+    //      count-based heuristic produced;
+    //   2. a large flush is delivered in full, with every batch within the size cap and a
+    //      sane batch count (no int-overflow, no oversized batch);
+    //   3. an oversize message is NOT silently swallowed as a whole chunk: its siblings are
+    //      still sent, only the single undeliverable message is dropped, and that drop is logged.
     public class ServiceBusBatchSizeTests
     {
-        private const int MaxBatch = 256 * 1024; // ServiceBusTarget.MaxBatchSizeBytes default
-
-        [Fact]
-        public void LargeFlushSizeEstimateDoesNotOverflow()
+        private static ServiceBusMock CreateTarget(int maxBatchSizeBytes, out LogFactory logFactory, out Logger logger)
         {
-            const int maxBodyBytes = 200_000; // ~200KB messages (each individually under the 256KB limit)
-            const int count = 20_000;         // a large flush
+            logFactory = new LogFactory();
+            var logConfig = new LoggingConfiguration(logFactory);
+            var serviceBusMock = new ServiceBusMock();
+            var target = new ServiceBusTarget(serviceBusMock)
+            {
+                ConnectionString = "LocalServiceBus",
+                QueueName = "${shortdate}",
+                Layout = "${message}",
+                MaxBatchSizeBytes = maxBatchSizeBytes,
+                BatchSize = 10000,                                              // deliver the flush in one WriteAsyncTask call
+                OverflowAction = Targets.Wrappers.AsyncTargetWrapperOverflowAction.Grow,
+                TaskDelayMilliseconds = 1,
+            };
+            logConfig.AddRuleForAllLevels(target);
+            logFactory.Configuration = logConfig;
+            logger = logFactory.GetLogger(nameof(ServiceBusBatchSizeTests));
+            return serviceBusMock;
+        }
 
-            // The true byte estimate (~12 GB) is far beyond a single 256KB batch -> the flush must split.
-            long trueTotal = (long)ServiceBusTarget.EstimateEventDataSize(maxBodyBytes) * count;
-            Assert.True(trueTotal > MaxBatch, "sanity: this flush genuinely needs many batches");
-
-            long estimate = ServiceBusTarget.EstimateBatchSizeBytes(maxBodyBytes, count);
-            Assert.True(estimate > 0, $"size estimate overflowed to {estimate} (negative) for a large flush");
-            Assert.Equal(trueTotal, estimate); // long arithmetic must keep the full magnitude (no overflow, no cap)
+        private static List<List<ServiceBusMessage>> SnapshotBatches(ServiceBusMock mock)
+        {
+            lock (mock.MessageDataSent)
+                return mock.MessageDataSent.Select(b => new List<ServiceBusMessage>(b)).ToList();
         }
 
         [Fact]
-        public void LargeFlushIsSplitIntoSmallBatches()
+        public void PayloadJustOverLimit_SplitsIntoFewBatches_NotMany()
         {
-            const int maxBodyBytes = 200_000;
-            const int count = 20_000;
+            const int cap = 1000;
+            var mock = CreateTarget(cap, out var logFactory, out var logger);
 
-            var target = new ServiceBusTarget { MaxBatchSizeBytes = MaxBatch };
-            var messages = new ServiceBusMessage[count]; // CalculateBatchSize only reads .Count
-            long estimate = ServiceBusTarget.EstimateBatchSizeBytes(maxBodyBytes, count);
+            // 5 x 300 bytes = 1500 bytes, just over a 1000-byte cap -> needs 2 batches (3 + 2).
+            for (int i = 0; i < 5; ++i)
+                logger.Info(new string('a', 300));
+            logFactory.Flush();
 
-            int perBatch = target.CalculateBatchSize(messages, estimate);
+            var batches = SnapshotBatches(mock);
+            int totalSent = batches.Sum(b => b.Count);
 
-            // Overflow -> negative estimate -> CalculateBatchSize returns Math.Min(count, 100) = 100,
-            // so each send packs ~100 x 200KB = ~20MB >> 256KB and is rejected. The fix must split small.
-            Assert.True(perBatch < 100, $"a {count}-message flush was placed into batches of {perBatch} (the overflow took the 'small total' path -> oversized batches)");
+            Assert.Equal(5, totalSent);                                        // nothing lost
+            Assert.True(batches.Count >= 2 && batches.Count <= 3,
+                $"expected ~2 batches for a payload just over the limit, got {batches.Count} (old count-based math produced >=10)");
+            Assert.All(batches, b => Assert.True(BodyBytes(b) <= cap, $"batch of {BodyBytes(b)} bytes exceeds the {cap}-byte cap"));
+        }
+
+        [Fact]
+        public void LargeFlush_DeliveredInFull_WithSaneBatchCountAndNoOversizedBatch()
+        {
+            const int cap = 4096;
+            const int count = 1000;
+            const int bodyBytes = 500;                                         // 8 messages per 4096-byte batch
+            var mock = CreateTarget(cap, out var logFactory, out var logger);
+
+            for (int i = 0; i < count; ++i)
+                logger.Info(new string('x', bodyBytes));
+            logFactory.Flush();
+
+            var batches = SnapshotBatches(mock);
+            int totalSent = batches.Sum(b => b.Count);
+
+            Assert.Equal(count, totalSent);                                    // no overflow, no whole-chunk drop
+            Assert.All(batches, b => Assert.True(BodyBytes(b) <= cap, $"batch of {BodyBytes(b)} bytes exceeds the {cap}-byte cap"));
+            // ~125 batches expected. Old math over-split to one-message-per-batch (~1000).
+            Assert.True(batches.Count > 1 && batches.Count <= count / 4,
+                $"expected a sane batch count near {count * bodyBytes / cap}, got {batches.Count}");
+        }
+
+        [Fact]
+        public void OversizeMessage_IsDroppedAndLogged_SiblingsStillSent()
+        {
+            const int cap = 1000;
+            var mock = CreateTarget(cap, out var logFactory, out var logger);
+
+            var originalWriter = InternalLogger.LogWriter;
+            var originalLevel = InternalLogger.LogLevel;
+            var capture = new StringWriter();
+            InternalLogger.LogWriter = capture;
+            InternalLogger.LogLevel = LogLevel.Error;
+            try
+            {
+                logger.Info(new string('a', 300));
+                logger.Info(new string('b', 300));
+                logger.Info(new string('g', 5000));     // larger than the 1000-byte cap -> undeliverable on its own
+                logger.Info(new string('c', 300));
+                logger.Info(new string('d', 300));
+                logFactory.Flush();
+            }
+            finally
+            {
+                InternalLogger.LogWriter = originalWriter;
+                InternalLogger.LogLevel = originalLevel;
+            }
+
+            var batches = SnapshotBatches(mock);
+            var delivered = batches.SelectMany(b => b).Select(m => Encoding.UTF8.GetString(m.Body)).ToList();
+
+            Assert.Equal(4, delivered.Count);                                  // the 4 siblings still send
+            Assert.DoesNotContain(delivered, body => body.Length == 5000);     // the oversize one is gone
+            Assert.All(delivered, body => Assert.Equal(300, body.Length));
+            Assert.All(batches, b => Assert.True(BodyBytes(b) <= cap));
+            // Dropped distinctly, not lost silently and not swallowed as a whole chunk.
+            Assert.Contains("Dropped 1 logevents", capture.ToString());
+        }
+
+        private static int BodyBytes(IEnumerable<ServiceBusMessage> batch)
+        {
+            return batch.Sum(m => m.Body.ToMemory().Length);
         }
     }
 }

--- a/test/NLog.Extensions.AzureServiceBus.Tests/ServiceBusBatchSizeTests.cs
+++ b/test/NLog.Extensions.AzureServiceBus.Tests/ServiceBusBatchSizeTests.cs
@@ -20,6 +20,12 @@ namespace NLog.Extensions.AzureServiceBus.Test
     //      sane batch count (no int-overflow, no oversized batch);
     //   3. an oversize message is NOT silently swallowed as a whole chunk: its siblings are
     //      still sent, only the single undeliverable message is dropped, and that drop is logged.
+    // Isolated from the assembly's parallel runs because OversizeMessage_IsDroppedAndLogged_SiblingsStillSent
+    // mutates the global InternalLogger.LogWriter/LogLevel.
+    [CollectionDefinition("InternalLogger isolation", DisableParallelization = true)]
+    public class InternalLoggerIsolationCollection { }
+
+    [Collection("InternalLogger isolation")]
     public class ServiceBusBatchSizeTests
     {
         private static ServiceBusMock CreateTarget(int maxBatchSizeBytes, out LogFactory logFactory, out Logger logger)

--- a/test/NLog.Extensions.AzureServiceBus.Tests/ServiceBusMock.cs
+++ b/test/NLog.Extensions.AzureServiceBus.Tests/ServiceBusMock.cs
@@ -75,6 +75,8 @@ namespace NLog.Extensions.AzureServiceBus.Test
 
             public int Count => _messages.Count;
 
+            public long MaximumSizeInBytes => _maxSizeBytes;
+
             public bool TryAddMessage(ServiceBusMessage message)
             {
                 int messageSize = message.Body.ToMemory().Length;

--- a/test/NLog.Extensions.AzureServiceBus.Tests/ServiceBusMock.cs
+++ b/test/NLog.Extensions.AzureServiceBus.Tests/ServiceBusMock.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 using NLog.Extensions.AzureBlobStorage;
@@ -10,6 +11,7 @@ namespace NLog.Extensions.AzureServiceBus.Test
 {
     class ServiceBusMock : ICloudServiceBus
     {
+        // One inner list per batch that was actually sent (in send order, per partition).
         public List<List<ServiceBusMessage>> MessageDataSent { get; } = new List<List<ServiceBusMessage>>();
         public string ConnectionString { get; private set; }
         public string EntityPath { get; private set; }
@@ -39,16 +41,13 @@ namespace NLog.Extensions.AzureServiceBus.Test
             DefaultTimeToLive = timeToLive;
         }
 
-        public Task SendAsync(IEnumerable<ServiceBusMessage> messages, System.Threading.CancellationToken cancellationToken)
+        public Task<IServiceBusMessageBatch> CreateMessageBatchAsync(int maxBatchSizeBytes, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(ConnectionString))
                 throw new InvalidOperationException("ServiceBusService not connected");
 
-            return Task.Delay(10, cancellationToken).ContinueWith(t =>
-            {
-                lock (MessageDataSent)
-                    MessageDataSent.Add(new List<ServiceBusMessage>(messages));
-            }, cancellationToken);
+            int cap = maxBatchSizeBytes > 0 ? maxBatchSizeBytes : int.MaxValue;
+            return Task.FromResult<IServiceBusMessageBatch>(new FakeMessageBatch(this, cap));
         }
 
         public async Task CloseAsync()
@@ -56,6 +55,52 @@ namespace NLog.Extensions.AzureServiceBus.Test
             await Task.Delay(1).ConfigureAwait(false);
             lock (MessageDataSent)
                 MessageDataSent.Clear();
+        }
+
+        // Mimics ServiceBusMessageBatch: TryAddMessage caps the batch at maxSizeBytes (measured by
+        // the message body length), so a full batch must be sealed/sent before the next one starts,
+        // and a single message larger than the cap can never be added to an empty batch.
+        private sealed class FakeMessageBatch : IServiceBusMessageBatch
+        {
+            private readonly ServiceBusMock _owner;
+            private readonly int _maxSizeBytes;
+            private readonly List<ServiceBusMessage> _messages = new List<ServiceBusMessage>();
+            private long _sizeBytes;
+
+            public FakeMessageBatch(ServiceBusMock owner, int maxSizeBytes)
+            {
+                _owner = owner;
+                _maxSizeBytes = maxSizeBytes;
+            }
+
+            public int Count => _messages.Count;
+
+            public bool TryAddMessage(ServiceBusMessage message)
+            {
+                int messageSize = message.Body.ToMemory().Length;
+                long newSize = _sizeBytes + messageSize;
+                if (_messages.Count > 0 && newSize > _maxSizeBytes)
+                    return false;   // batch full -> caller seals and sends, then retries on a fresh batch
+                if (_messages.Count == 0 && messageSize > _maxSizeBytes)
+                    return false;   // single message too large to ever fit
+                _sizeBytes = newSize;
+                _messages.Add(message);
+                return true;
+            }
+
+            public Task SendAsync(CancellationToken cancellationToken)
+            {
+                var snapshot = new List<ServiceBusMessage>(_messages);
+                return Task.Delay(5, cancellationToken).ContinueWith(t =>
+                {
+                    lock (_owner.MessageDataSent)
+                        _owner.MessageDataSent.Add(snapshot);
+                }, cancellationToken);
+            }
+
+            public void Dispose()
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
## What & why

Both the **ServiceBus** and **EventHub** targets hand-rolled batch sizing instead of using the Azure SDK's native batch builders. This PR replaces that with `ServiceBusMessageBatch`/`EventDataBatch` + `TryAdd`, so batch size limits are enforced by the SDK itself. It completes **S3** (only the minimal int-overflow guard shipped earlier in #197).

### Defects fixed
1. **Over-/under-splitting math** — the size estimate inflated an already-byte length with `(len+128)*3+128`, forced `numberOfBatches = max(total/max, 10)` (≥10 chunks even for a tiny overflow), then shrank with `-1`. Net effect: far more network calls than necessary. Now `TryAdd` packs each batch to the real limit → a payload just over the max splits into **~2 batches, not ≥10**.
2. **O(n²) chunking** — `GenerateBatches` did `source.Skip(i).Take(n)` over an `IList`. Replaced by a single **O(n)** `TryAdd` pass.
3. **Whole-chunk silent drop** ⚠️ — `WriteMultipleBatchesAsync` caught `MessageSizeExceeded`/`QuotaExceeded` and **swallowed the entire chunk**, silently dropping every message in it. That swallow is gone: nothing oversized is ever sent (`TryAdd` prevents it), so there is no chunk to drop and genuine send failures (e.g. throttling) propagate to NLog for retry. Only a message that can't fit in an *empty* batch is truly undeliverable — it's skipped so its **siblings still send**, and the dropped count is **logged distinctly** instead of being lost silently. This also removes the old inconsistency where the single-event path threw but the multi-batch path dropped.
4. **Non-authoritative sizing** — the estimate couldn't know the real per-message AMQP overhead or the namespace's negotiated max size. `TryAdd` does.

## Route taken: native SDK migration (the preferred direction)

Rather than the acceptable staged fallback, this takes the full native route because the interfaces (`ICloudServiceBus`, `IEventHubService`) are `internal` and used only by the target + mock, so the blast radius is contained.

The split is driven through a thin **injectable batch seam** so it stays unit-testable without Azurite:
- ServiceBus: `ICloudServiceBus.CreateMessageBatchAsync(maxBytes, ct)` → `IServiceBusMessageBatch { Count; TryAddMessage; SendAsync; Dispose }`. Production wraps `ServiceBusSender.CreateMessageBatchAsync` + `SendMessagesAsync(batch)`.
- EventHub: `IEventHubService.CreateBatchAsync(partitionKey, maxBytes, ct)` → `IEventDataBatch { Count; TryAddEvent; SendAsync; Dispose }`. Production wraps `EventHubProducerClient.CreateBatchAsync(options)` + `SendAsync(batch)`; the partition key is carried on `CreateBatchOptions.PartitionKey` (the per-event `SendEventOptions` cache is no longer needed).

The target loop is identical for both: `TryAdd` until a batch is full → seal + send → start a new one; ServiceBus partition/session bucketing is preserved exactly (it's already per-message + pre-bucketed). The configured `MaxBatchSizeBytes` is passed through as the requested cap with a fallback to the SDK's negotiated max if it's exceeded.

## How the tests prove no whole-chunk drop

Each `*ServiceMock` gains a fake batch that caps at `MaxBatchSizeBytes` (by body bytes), reproducing `TryAdd` overflow deterministically. Three tests per target (driven end-to-end through `LogFactory` + the mock):

- **`PayloadJustOverLimit_SplitsIntoFewBatches_NotMany`** — 5×300 B over a 1000 B cap → exactly 2 batches (the old count-based math produced ~one-per-message), all 5 delivered, no batch over the cap.
- **`LargeFlush_DeliveredInFull_WithSaneBatchCountAndNoOversizedBatch`** — 1000×500 B over a 4096 B cap → all 1000 delivered, every batch ≤ cap, ~125 batches (no int-overflow, no oversized send). Replaces #197's overflow coverage (overflow is now structurally impossible).
- **`OversizeMessage/Event_IsDroppedAndLogged_SiblingsStillSent`** — a 5000 B message among four 300 B siblings over a 1000 B cap → the 4 siblings are delivered across 2 batches, the oversize one is dropped (not the whole chunk), and a distinct `Dropped 1 logevents` line is logged. This is the faulting-send case: the oversize condition is **not** silently swallowed.

Revert check: regressing the splitting loop to advance past un-fittable messages makes all three new tests fail while the existing target tests still pass.

## Verify
Both src projects build clean across `netstandard2.0;net8.0;net10.0` with `TreatWarningsAsErrors=true` (0 warnings). Tests target net8.0 and were run with `DOTNET_ROLL_FORWARD=Major`:
- `NLog.Extensions.AzureServiceBus.Tests`: 6 passed (3 existing + 3 new)
- `NLog.Extensions.AzureEventHub.Tests`: 7 passed (4 existing + 3 new)

Mirrors the style/scope of #192–#200. **Do not merge** — opened for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)