### PR TITLE
Fix DataTables batch integrity: stop one un-renderable event from sinking the whole atomic batch

### DIFF
--- a/src/NLog.Extensions.AzureDataTables/DataTablesTarget.cs
+++ b/src/NLog.Extensions.AzureDataTables/DataTablesTarget.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Data.Tables;
@@ -344,7 +343,13 @@ namespace NLog.Targets
                 {
                     if (partitionBucket.Value.Count <= BatchMaxSize)
                     {
-                        var batchItem = GenerateBatch(partitionBucket.Value, partitionKey);
+                        // Render the entities EAGERLY here (inside the guard) so a single un-renderable
+                        // event is dropped rather than faulting the whole atomic transaction when the SDK
+                        // enumerates the batch later, during SubmitTransactionAsync.
+                        var batchItem = GenerateBatch(partitionBucket.Value, 0, partitionBucket.Value.Count, partitionKey, tableName);
+                        if (batchItem.Count == 0)
+                            continue;   // every event in this partition failed to render; nothing valid to submit
+
                         var writeTask = WriteToTableAsync(tableName, batchItem, cancellationToken);
                         if (multipleTasks == null)
                             return writeTask;
@@ -354,7 +359,7 @@ namespace NLog.Targets
                     else
                     {
                         // Must chain the tasks together so they don't run concurrently
-                        var batchCollection = GenerateBatches(partitionBucket.Value, partitionKey, BatchMaxSize);
+                        var batchCollection = GenerateBatches(partitionBucket.Value, partitionKey, tableName, BatchMaxSize);
                         Task writeTask = WriteMultipleBatchesAsync(batchCollection, tableName, cancellationToken);
                         if (multipleTasks == null)
                             return writeTask;
@@ -381,15 +386,47 @@ namespace NLog.Targets
             }
         }
 
-        IEnumerable<IEnumerable<TableTransactionAction>> GenerateBatches(IList<LogEventInfo> source, string partitionKey, int batchSize)
+        // Split a >100-event partition into <=batchSize transactions, building every entity EAGERLY (so a
+        // render failure is contained per-event) and slicing the IList by index (O(n), not Skip/Take's O(n^2)
+        // on frameworks whose Enumerable.Skip is not IList-optimized).
+        private List<List<TableTransactionAction>> GenerateBatches(IList<LogEventInfo> source, string partitionKey, string tableName, int batchSize)
         {
+            var batches = new List<List<TableTransactionAction>>((source.Count + batchSize - 1) / batchSize);
             for (int i = 0; i < source.Count; i += batchSize)
-                yield return GenerateBatch(source.Skip(i).Take(batchSize), partitionKey);
+            {
+                var batch = GenerateBatch(source, i, Math.Min(batchSize, source.Count - i), partitionKey, tableName);
+                if (batch.Count > 0)
+                    batches.Add(batch);
+            }
+            return batches;
         }
 
-        private IEnumerable<TableTransactionAction> GenerateBatch(IEnumerable<LogEventInfo> logEvents, string partitionKey)
+        // Render source[startIndex .. startIndex+count) into transaction actions, EAGERLY. An event whose
+        // layout/property rendering throws is dropped (and counted) so the remaining events still form a
+        // valid atomic transaction, instead of one poison event faulting the whole batch from inside the
+        // SDK's deferred enumeration during SubmitTransactionAsync.
+        private List<TableTransactionAction> GenerateBatch(IList<LogEventInfo> source, int startIndex, int count, string partitionKey, string tableName)
         {
-            return logEvents.Select(evt => GenerateTableTransactionAction(partitionKey, evt));
+            var batch = new List<TableTransactionAction>(count);
+            int dropped = 0;
+            int end = startIndex + count;
+            for (int i = startIndex; i < end; ++i)
+            {
+                try
+                {
+                    batch.Add(GenerateTableTransactionAction(partitionKey, source[i]));
+                }
+                catch (Exception ex)
+                {
+                    ++dropped;
+                    InternalLogger.Warn(ex, "AzureDataTablesTarget(Name={0}): Skipping logevent that failed to render for Table={1} with PartitionKey={2}", Name, tableName, partitionKey);
+                }
+            }
+
+            if (dropped > 0)
+                InternalLogger.Error("AzureDataTablesTarget(Name={0}): Dropped {1} logevents that failed to render for Table={2} with PartitionKey={3}", Name, dropped, tableName, partitionKey);
+
+            return batch;
         }
 
         private TableTransactionAction GenerateTableTransactionAction(string partitionKey, LogEventInfo evt)
@@ -438,8 +475,14 @@ namespace NLog.Targets
             if (ContextProperties.Count > 0)
             {
                 var entity = new TableEntity(partitionKey, rowKey);
-                bool logTimeStampOverridden = "LogTimeStamp".Equals(ContextProperties[0].Name, StringComparison.OrdinalIgnoreCase);
-                if (!logTimeStampOverridden)
+
+                // A user-defined "LogTimeStamp" context property overrides the library default. Detect it
+                // at ANY index (not just [0]): otherwise a LogTimeStamp at index >= 1 left the default in
+                // place, so an empty override leaked the default timestamp and the skip-when-empty semantics
+                // were silently positional. (TableEntity.Add overwrites a duplicate key, so this is a leaked
+                // default rather than a crash.)
+                int logTimeStampIndex = IndexOfLogTimeStampProperty();
+                if (logTimeStampIndex < 0)
                 {
                     entity.Add("LogTimeStamp", logEvent.TimeStamp.ToUniversalTime());
                 }
@@ -451,8 +494,8 @@ namespace NLog.Targets
                         continue;
 
                     var propertyValue = RenderLogEvent(contextproperty.Layout, logEvent) ?? string.Empty;
-                    if (logTimeStampOverridden && i == 0 && string.IsNullOrEmpty(propertyValue))
-                        continue;
+                    if (i == logTimeStampIndex && string.IsNullOrEmpty(propertyValue))
+                        continue;   // honor the override's skip-when-empty at any index (no default was added)
 
                     if (!contextproperty.IncludeEmptyValue && string.IsNullOrEmpty(propertyValue))
                         continue;
@@ -478,6 +521,17 @@ namespace NLog.Targets
                 }
                 return new NLogEntity(logEvent, layoutMessage, _machineName, partitionKey, rowKey, LogTimeStampFormat);
             }
+        }
+
+        // Index of the first context property that overrides the default "LogTimeStamp" column, or -1.
+        private int IndexOfLogTimeStampProperty()
+        {
+            for (int i = 0; i < ContextProperties.Count; ++i)
+            {
+                if ("LogTimeStamp".Equals(ContextProperties[i].Name, StringComparison.OrdinalIgnoreCase))
+                    return i;
+            }
+            return -1;
         }
 
         private string CheckAndRepairTableName(string tableName)

--- a/test/NLog.Extensions.AzureDataTables.Tests/CloudTableServiceMock.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/CloudTableServiceMock.cs
@@ -31,24 +31,25 @@ namespace NLog.Extensions.AzureTableStorage.Tests
             ConnectionString = connectionString;
         }
 
-        public Task SubmitTransactionAsync(string tableName, IEnumerable<TableTransactionAction> tableTransaction, CancellationToken cancellationToken)
+        public async Task SubmitTransactionAsync(string tableName, IEnumerable<TableTransactionAction> tableTransaction, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(ConnectionString))
                 throw new InvalidOperationException("CloudTableService not connected");
 
-            return Task.Delay(10).ContinueWith(t =>
+            // Honor the cancellation token like the production CloudTableService does: a cancelled token
+            // throws here and commits nothing, rather than silently committing after cancellation.
+            await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+
+            // Azure ENUMERATES the transaction (rendering each entity) and commits it all-or-nothing.
+            // Materialize here so a deferred render exception faults the whole transaction and records
+            // nothing -- exactly the silent whole-batch loss the eager-build fix is meant to prevent --
+            // rather than being quietly deferred past the target's guard.
+            var materialized = tableTransaction.ToList();
+            lock (_sync)
             {
-                // Azure ENUMERATES the transaction (rendering each entity) and commits it all-or-nothing.
-                // Materialize here so a deferred render exception faults the whole transaction and records
-                // nothing -- exactly the silent whole-batch loss the eager-build fix is meant to prevent --
-                // rather than being quietly deferred past the target's guard.
-                var materialized = tableTransaction.ToList();
-                lock (_sync)
-                {
-                    BatchExecuted[tableName] = materialized;
-                    Transactions.Add(new KeyValuePair<string, List<TableTransactionAction>>(tableName, materialized));
-                }
-            });
+                BatchExecuted[tableName] = materialized;
+                Transactions.Add(new KeyValuePair<string, List<TableTransactionAction>>(tableName, materialized));
+            }
         }
 
         public IEnumerable<ITableEntity> PeekLastAdded(string tableName)

--- a/test/NLog.Extensions.AzureDataTables.Tests/CloudTableServiceMock.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/CloudTableServiceMock.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -11,7 +11,14 @@ namespace NLog.Extensions.AzureTableStorage.Tests
 {
     class CloudTableServiceMock : ICloudTableService, IDisposable
     {
+        private readonly object _sync = new object();
+
+        // Last transaction submitted per table (kept for the existing single-batch tests/PeekLastAdded).
         public Dictionary<string, IEnumerable<TableTransactionAction>> BatchExecuted { get; } = new Dictionary<string, IEnumerable<TableTransactionAction>>();
+
+        // Every transaction submitted, in submission order. Azure commits each transaction atomically,
+        // so a transaction that throws while being enumerated commits NOTHING and is not recorded here.
+        public List<KeyValuePair<string, List<TableTransactionAction>>> Transactions { get; } = new List<KeyValuePair<string, List<TableTransactionAction>>>();
 
         public int DisposeCount { get; private set; }
 
@@ -31,22 +38,48 @@ namespace NLog.Extensions.AzureTableStorage.Tests
 
             return Task.Delay(10).ContinueWith(t =>
             {
-                lock (BatchExecuted)
-                    BatchExecuted[tableName] = tableTransaction;
+                // Azure ENUMERATES the transaction (rendering each entity) and commits it all-or-nothing.
+                // Materialize here so a deferred render exception faults the whole transaction and records
+                // nothing -- exactly the silent whole-batch loss the eager-build fix is meant to prevent --
+                // rather than being quietly deferred past the target's guard.
+                var materialized = tableTransaction.ToList();
+                lock (_sync)
+                {
+                    BatchExecuted[tableName] = materialized;
+                    Transactions.Add(new KeyValuePair<string, List<TableTransactionAction>>(tableName, materialized));
+                }
             });
         }
 
         public IEnumerable<ITableEntity> PeekLastAdded(string tableName)
         {
-            lock (BatchExecuted)
+            lock (_sync)
             {
                 if (BatchExecuted.TryGetValue(tableName, out var tableOperation))
                 {
-                    return tableOperation.Select(t => t.Entity);
+                    return tableOperation.Select(t => t.Entity).ToList();
                 }
             }
 
             return null;
+        }
+
+        // Each atomic transaction committed for a table, in submission order (one inner list per batch).
+        public IReadOnlyList<IReadOnlyList<ITableEntity>> GetBatches(string tableName)
+        {
+            lock (_sync)
+            {
+                return Transactions
+                    .Where(x => x.Key == tableName)
+                    .Select(x => (IReadOnlyList<ITableEntity>)x.Value.Select(a => a.Entity).ToList())
+                    .ToList();
+            }
+        }
+
+        // Every entity committed for a table across all of its batches.
+        public IEnumerable<ITableEntity> PeekAllAdded(string tableName)
+        {
+            return GetBatches(tableName).SelectMany(b => b).ToList();
         }
     }
 }

--- a/test/NLog.Extensions.AzureDataTables.Tests/DataTablesBatchIntegrityTests.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/DataTablesBatchIntegrityTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using System.Linq;
+using Azure.Data.Tables;
+using NLog;
+using NLog.Common;
+using NLog.Config;
+using NLog.Layouts;
+using NLog.Targets;
+using Xunit;
+
+namespace NLog.Extensions.AzureTableStorage.Tests
+{
+    // Azure table transactions are ATOMIC (<=100 entities, one partition, all-or-nothing). GenerateBatch
+    // returned a lazy `Select`, so the per-event entity render (layouts/properties) was deferred OUT of
+    // WriteAsyncTask's try/catch and INTO the SDK's enumeration during SubmitTransactionAsync. A single
+    // event whose layout throws there faulted the WHOLE transaction -> every good sibling in the partition
+    // was lost (and, since exceptions now propagate to AsyncTaskTarget, the retried batch failed again and
+    // was ultimately dropped). The fix builds entities EAGERLY inside the guard and drops only the poison
+    // event so the remaining events still form a valid transaction.
+    //
+    // Note on the trigger: NLog precalculates VOLATILE layouts on the logging thread (a throw there drops
+    // just that one event upstream). Only [ThreadAgnostic] layouts -- and the always-deferred RowKey -- are
+    // rendered later, during the batch build. So a [ThreadAgnostic] throwing layout is the realistic poison.
+    [ThreadAgnostic]
+    sealed class PoisonLayout : Layout
+    {
+        private readonly string _trigger;
+        public PoisonLayout(string trigger) { _trigger = trigger; }
+
+        protected override string GetFormattedMessage(LogEventInfo logEvent)
+            => logEvent.Message == _trigger ? throw new InvalidOperationException("render boom") : logEvent.Message;
+
+        protected override void RenderFormattedMessage(LogEventInfo logEvent, System.Text.StringBuilder target)
+        {
+            if (logEvent.Message == _trigger) throw new InvalidOperationException("render boom");
+            target.Append(logEvent.Message);
+        }
+    }
+
+    // OversizeMessage-style tests mutate the global InternalLogger.LogWriter/LogLevel; isolate them.
+    [CollectionDefinition("DataTables InternalLogger isolation", DisableParallelization = true)]
+    public class DataTablesInternalLoggerIsolationCollection { }
+
+    [Collection("DataTables InternalLogger isolation")]
+    public class DataTablesBatchIntegrityTests
+    {
+        private const string Table = "PoisonTbl";
+
+        private static (LogFactory factory, CloudTableServiceMock svc, Logger logger) Build(int batchSize)
+        {
+            var logFactory = new LogFactory();
+            var logConfig = new LoggingConfiguration(logFactory);
+            logConfig.Variables["ConnectionString"] = nameof(DataTablesBatchIntegrityTests);
+            var svc = new CloudTableServiceMock();
+            var target = new DataTablesTarget(svc)
+            {
+                ConnectionString = "${var:ConnectionString}",
+                TableName = "${logger}",
+                Layout = "${message}",
+                BatchSize = batchSize,           // deliver the flush in a single WriteAsyncTask call
+                TaskDelayMilliseconds = 1,
+            };
+            target.ContextProperties.Add(new TargetPropertyWithContext("Payload", new PoisonLayout("POISON")));
+            logConfig.AddRuleForAllLevels(target);
+            logFactory.Configuration = logConfig;
+            return (logFactory, svc, logFactory.GetLogger(Table));
+        }
+
+        private static T CaptureInternalLog<T>(out string log, Func<T> action)
+        {
+            var originalWriter = InternalLogger.LogWriter;
+            var originalLevel = InternalLogger.LogLevel;
+            var capture = new StringWriter();
+            InternalLogger.LogWriter = capture;
+            InternalLogger.LogLevel = LogLevel.Error;
+            try { var r = action(); log = capture.ToString(); return r; }
+            finally
+            {
+                InternalLogger.LogWriter = originalWriter;
+                InternalLogger.LogLevel = originalLevel;
+            }
+        }
+
+        [Fact]
+        public void PoisonEvent_InSmallBatch_IsDroppedAndLogged_GoodSiblingsStillCommit()
+        {
+            var (factory, svc, logger) = Build(batchSize: 100);   // <=100 path
+
+            var committed = CaptureInternalLog(out var log, () =>
+            {
+                logger.Info("good-0");
+                logger.Info("good-1");
+                logger.Info("POISON");        // its layout throws at build time
+                logger.Info("good-3");
+                logger.Info("good-4");
+                factory.Flush();
+                return svc.PeekAllAdded(Table).Cast<TableEntity>().ToList();
+            });
+
+            var payloads = committed.Select(e => e["Payload"].ToString()).OrderBy(x => x).ToList();
+
+            // The 4 good events still commit (the whole batch is NOT lost); the poison is excluded.
+            Assert.Equal(new[] { "good-0", "good-1", "good-3", "good-4" }, payloads);
+            Assert.Single(svc.GetBatches(Table));                         // as one valid atomic transaction
+            Assert.Contains("Dropped 1 logevents", log);                  // distinctly logged, not silently lost
+        }
+
+        [Fact]
+        public void PoisonEvent_InLargeMultiBatchPartition_IsDroppedAndLogged_GoodSiblingsStillCommit()
+        {
+            var (factory, svc, logger) = Build(batchSize: 10000);  // all events in one call -> >100 path
+
+            var committed = CaptureInternalLog(out var log, () =>
+            {
+                for (int i = 0; i < 150; ++i)
+                    logger.Info(i == 50 ? "POISON" : "good-" + i);
+                factory.Flush();
+                return svc.PeekAllAdded(Table).Cast<TableEntity>().ToList();
+            });
+
+            var batches = svc.GetBatches(Table);
+
+            Assert.Equal(149, committed.Count);                           // 149 good events still commit
+            Assert.DoesNotContain(committed, e => e["Payload"].ToString() == "POISON");
+            Assert.True(batches.Count >= 2, $"expected the >100 partition to split, got {batches.Count} batch(es)");
+            Assert.All(batches, b => Assert.InRange(b.Count, 1, 100));    // each a valid <=100 transaction
+            Assert.Contains("Dropped 1 logevents", log);
+        }
+    }
+}

--- a/test/NLog.Extensions.AzureDataTables.Tests/DataTablesBatchingTests.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/DataTablesBatchingTests.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+using NLog;
+using NLog.Config;
+using NLog.Targets;
+using Xunit;
+
+namespace NLog.Extensions.AzureTableStorage.Tests
+{
+    // A partition with more than 100 events is split into multiple <=100-entity transactions. The old
+    // split indexed the IList with Skip(i).Take(n) (O(n^2) on frameworks whose Enumerable.Skip is not
+    // IList-optimized, e.g. netstandard2.0); the fix slices by index (O(n) everywhere). The split must
+    // remain correct: every event delivered, each batch a valid <=100-entity transaction.
+    public class DataTablesBatchingTests
+    {
+        private const string Table = "BatchTbl";
+
+        private static (LogFactory factory, CloudTableServiceMock svc, Logger logger) Build()
+        {
+            var logFactory = new LogFactory();
+            var logConfig = new LoggingConfiguration(logFactory);
+            logConfig.Variables["ConnectionString"] = nameof(DataTablesBatchingTests);
+            var svc = new CloudTableServiceMock();
+            var target = new DataTablesTarget(svc)
+            {
+                ConnectionString = "${var:ConnectionString}",
+                TableName = "${logger}",
+                Layout = "${message}",
+                BatchSize = 100000,          // deliver the whole flush in one WriteAsyncTask call (>100 path)
+                TaskDelayMilliseconds = 1,
+            };
+            logConfig.AddRuleForAllLevels(target);
+            logFactory.Configuration = logConfig;
+            return (logFactory, svc, logFactory.GetLogger(Table));
+        }
+
+        [Theory]
+        [InlineData(101)]
+        [InlineData(150)]
+        [InlineData(250)]
+        [InlineData(1001)]
+        public void PartitionOver100_SplitsIntoValidSubBatches_WithNoLoss(int count)
+        {
+            var (factory, svc, logger) = Build();
+
+            for (int i = 0; i < count; ++i)
+                logger.Info("m-" + i);
+            factory.Flush();
+
+            var batches = svc.GetBatches(Table);
+            int expectedBatches = (count + 99) / 100;
+
+            Assert.Equal(count, batches.Sum(b => b.Count));                  // nothing lost
+            Assert.Equal(count, svc.PeekAllAdded(Table).Count());            // same total via the flattened view
+            Assert.Equal(expectedBatches, batches.Count);                    // chunked into <=100 batches
+            Assert.All(batches, b => Assert.InRange(b.Count, 1, 100));       // each a valid atomic transaction
+        }
+    }
+}

--- a/test/NLog.Extensions.AzureDataTables.Tests/DataTablesLogTimeStampCollisionTests.cs
+++ b/test/NLog.Extensions.AzureDataTables.Tests/DataTablesLogTimeStampCollisionTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Linq;
+using Azure.Data.Tables;
+using NLog;
+using NLog.Config;
+using NLog.Layouts;
+using NLog.Targets;
+using Xunit;
+
+namespace NLog.Extensions.AzureTableStorage.Tests
+{
+    // A user can override the library's default "LogTimeStamp" column by adding a context property of
+    // that name. The override was only detected at ContextProperties[0], so a "LogTimeStamp" at index >= 1
+    // was NOT recognized as the override: the library default was still added, and the override's
+    // skip-when-empty semantics did not apply. (Azure.Data.Tables 12.11.0 TableEntity.Add OVERWRITES a
+    // duplicate key rather than throwing, so a non-empty user value still wins -- but an EMPTY user value
+    // leaks the library default. The fix detects the override at ANY index so behavior is position-independent.)
+    public class DataTablesLogTimeStampCollisionTests
+    {
+        private static TableEntity LogOnce(Action<DataTablesTarget> configure)
+        {
+            var logFactory = new LogFactory();
+            var logConfig = new LoggingConfiguration(logFactory);
+            logConfig.Variables["ConnectionString"] = nameof(DataTablesLogTimeStampCollisionTests);
+            var svc = new CloudTableServiceMock();
+            var target = new DataTablesTarget(svc)
+            {
+                ConnectionString = "${var:ConnectionString}",
+                TableName = "${logger}",
+                Layout = "${message}",
+            };
+            configure(target);
+            logConfig.AddRuleForAllLevels(target);
+            logFactory.Configuration = logConfig;
+            logFactory.GetLogger("Test").Info("hi");
+            logFactory.Flush();
+            return svc.PeekLastAdded("Test").Cast<TableEntity>().Single();
+        }
+
+        [Fact]
+        public void UserLogTimeStampAtIndex1_NonEmpty_WinsWithSingleValue_NoThrow()
+        {
+            var entity = LogOnce(t =>
+            {
+                t.ContextProperties.Add(new TargetPropertyWithContext("Other", "x"));
+                t.ContextProperties.Add(new TargetPropertyWithContext("LogTimeStamp", "2026-06-22"));
+            });
+
+            Assert.Equal("x", entity["Other"].ToString());
+            Assert.True(entity.ContainsKey("LogTimeStamp"));
+            Assert.Equal("2026-06-22", entity["LogTimeStamp"]);   // the user's value, stored as their string
+        }
+
+        [Fact]
+        public void UserLogTimeStampAtIndex1_Empty_DoesNotLeakLibraryDefault()
+        {
+            // Regression: with only ContextProperties[0] checked, a LogTimeStamp override at index 1 left
+            // the library default in place, so an empty user value leaked the default timestamp. A
+            // LogTimeStamp override at index 0 produces NO column for an empty value; index >= 1 must match.
+            var entity = LogOnce(t =>
+            {
+                t.ContextProperties.Add(new TargetPropertyWithContext("Other", "x"));
+                t.ContextProperties.Add(new TargetPropertyWithContext("LogTimeStamp", Layout.FromMethod(_ => string.Empty)));
+            });
+
+            Assert.False(entity.ContainsKey("LogTimeStamp"),
+                "an empty LogTimeStamp override at index >= 1 must not leak the library default (parity with index 0)");
+        }
+
+        [Fact]
+        public void UserLogTimeStampAtIndex0_NonEmpty_StillWins()
+        {
+            var entity = LogOnce(t =>
+            {
+                t.ContextProperties.Add(new TargetPropertyWithContext("LogTimeStamp", "2026-06-22"));
+                t.ContextProperties.Add(new TargetPropertyWithContext("Other", "x"));
+            });
+
+            Assert.Equal("2026-06-22", entity["LogTimeStamp"]);
+        }
+
+        [Fact]
+        public void NoUserLogTimeStamp_LibraryDefaultIsAdded()
+        {
+            var entity = LogOnce(t => t.ContextProperties.Add(new TargetPropertyWithContext("ThreadId", "${threadid}")));
+
+            Assert.True(entity.ContainsKey("LogTimeStamp"));
+            Assert.IsType<DateTime>(entity["LogTimeStamp"]);      // the library default is a DateTime, not a string
+        }
+    }
+}


### PR DESCRIPTION
Three independent, unit-testable fixes to `DataTablesTarget` (the BUGHUNT "DataTables cluster"), shipped test-first. **Reproduced live before writing tests** — which corrected two of the audit's premises (see below).

## 1. Lead — data loss: one un-renderable event silently sinks the whole atomic batch

`GenerateBatch` returned a lazy `logEvents.Select(evt => GenerateTableTransactionAction(...))`. Entity creation — and therefore **all layout/property rendering** — was deferred until the Azure SDK enumerated the sequence *inside* `SubmitTransactionAsync`, i.e. **after** `WriteAsyncTask`'s `try/catch`. Azure table transactions are atomic (≤100 entities, one partition, all-or-nothing), so a single event whose render throws faulted the **entire** transaction. Since S1 (#194) made these exceptions propagate to `AsyncTaskTarget`, the whole batch was retried, failed again deterministically, and the entire partition's logs were dropped — silently.

**Live reproduction** (`committed=0` for a 5-event flush, 4 good + 1 poison) pinned down the real trigger, which is narrower than the audit implied:
- NLog 5.2.5 **swallows** `Layout.FromMethod` exceptions (returns `""`), so those never fault anything.
- A throwing layout only escapes when it is **`[ThreadAgnostic]`** (or the always-deferred RowKey/PartitionKey): volatile layouts are precalculated on the logging thread, where a throw drops just that one event upstream. `[ThreadAgnostic]` layouts are rendered later, during the batch build — that's the deferred path that loses the batch.

**Fix:** build entities **eagerly inside the guard** and, on a per-event render failure, **drop + log that one event** (distinct `InternalLogger` line + a `Dropped {n} logevents` count) so the remaining events still form a valid transaction. Applies to both the ≤100 and >100 (`GenerateBatches`) paths; an all-poison (empty) batch is skipped rather than submitted. This mirrors the drop-and-log idiom shipped for S3 (#201).

## 2. `LogTimeStamp` override only detected at `ContextProperties[0]`

The audit predicted a duplicate-key **crash**. That is **not** what happens: `Azure.Data.Tables` 12.11.0 `TableEntity.Add` **overwrites** a duplicate key rather than throwing. The real bug is a **leaked default**: the override was only recognised at index 0, so a `LogTimeStamp` context property at index ≥ 1 still got the library default added, and the override's skip-when-empty semantics were silently positional. Proven by a position × empty-value matrix:

| value | `LogTimeStamp` at index 0 | at index ≥ 1 (before fix) |
|-------|---------------------------|---------------------------|
| empty | *(no column)* | **library default `DateTime` leaks** |
| non-empty | user value | user value (overwrite) |

**Fix:** detect the `LogTimeStamp` override at **any** index (case-insensitive) to decide whether to add the default and to honour skip-when-empty — behaviour is now position-independent. Existing intended behaviour (user value wins; empty-value skip) is preserved.

## 3. O(n²) `Skip/Take` over an `IList`

`GenerateBatches` sliced the partition with `source.Skip(i).Take(batchSize)`. On frameworks whose `Enumerable.Skip` is **not** IList-optimized (e.g. the `netstandard2.0` target) this is O(n²). The fix slices by index — O(n) on every TFM. It falls out naturally of the eager build. (On the net8 test runtime `Skip` *is* IList-optimized, so there is no observable timing difference there; the regression test asserts batching **correctness** rather than a flaky timing bound.)

## Tests — how they prove a bad event no longer sinks the batch

Extended the existing mock harness. `CloudTableServiceMock` now **enumerates each transaction eagerly** (modelling Azure's all-or-nothing commit, so a deferred render throw faults the whole transaction and commits nothing) and captures **every** batch.

- **Defect 1 (`DataTablesBatchIntegrityTests`)** — a `[ThreadAgnostic]` poison layout throws on one event among good siblings, for both the ≤100 and >100-event paths. Asserts the good events still commit as valid ≤100 transactions, the poison is excluded, and a distinct `Dropped 1 logevents` is logged — not the whole batch lost.
- **Defect 2 (`DataTablesLogTimeStampCollisionTests`)** — a `LogTimeStamp` property at index ≥ 1: empty no longer leaks the default; non-empty wins as a single value with no throw; the index-0 and no-override (default) paths still work.
- **Defect 3 (`DataTablesBatchingTests`)** — >100-event partitions split into correct ≤100 chunks with no loss.

**Revert verification:** reverting *only* the per-event drop fails exactly the two Defect-1 tests (Defect-2 still green); reverting *only* the any-index `LogTimeStamp` detection fails exactly the Defect-2 empty-leak test (Defect-1 still green). Full DataTables suite: 34/34 green; src builds clean across `netstandard2.0;net8.0;net10.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)