### PR TITLE
Fix S5 shutdown teardown: observe CloseAsync outcome + bound the wait (EventHub/ServiceBus)

### DIFF
--- a/src/NLog.Extensions.AzureEventHub/EventHubTarget.cs
+++ b/src/NLog.Extensions.AzureEventHub/EventHubTarget.cs
@@ -313,14 +313,62 @@ namespace NLog.Targets
             }
         }
 
+        // Upper bound on how long shutdown blocks waiting for the connection to close. Generous
+        // enough for a healthy-but-slow teardown (the old hard 500ms cap truncated those), yet
+        // bounded so a hung SDK close cannot stall process shutdown. On timeout the close is not
+        // abandoned: its outcome is still observed asynchronously so a later fault never becomes an
+        // unobserved task exception.
+        private static readonly TimeSpan ConnectionCloseTimeout = TimeSpan.FromSeconds(5);
+
         /// <summary>
         /// Closes the target and releases any unmanaged resources.
         /// </summary>
         protected override void CloseTarget()
         {
-            var task = Task.Run(async () => await _eventHubService.CloseAsync().ConfigureAwait(false));
-            task.Wait(TimeSpan.FromMilliseconds(500));
-            base.CloseTarget();
+            try
+            {
+                // Let NLog drain any remaining queued events over the still-open connection first,
+                // then close the connection - never the other way around.
+                base.CloseTarget();
+            }
+            finally
+            {
+                CloseConnection();
+            }
+        }
+
+        private void CloseConnection()
+        {
+            try
+            {
+                var closeTask = Task.Run(() => _eventHubService.CloseAsync());
+
+                bool completed;
+                try
+                {
+                    completed = closeTask.Wait(ConnectionCloseTimeout);
+                }
+                catch (Exception ex)
+                {
+                    // CloseAsync faulted within the wait window - observed here, logged, not rethrown.
+                    InternalLogger.Warn(ex.GetBaseException(), "AzureEventHubTarget(Name={0}): Failed to close EventHubClient connection during shutdown", Name);
+                    return;
+                }
+
+                if (!completed)
+                {
+                    // Still closing after the bound: observe the eventual outcome so a later fault is
+                    // never an unobserved task exception, and surface it via InternalLogger.
+                    closeTask.ContinueWith(
+                        t => InternalLogger.Warn(t.Exception?.GetBaseException(), "AzureEventHubTarget(Name={0}): Failed to close EventHubClient connection during shutdown", Name),
+                        CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+                    InternalLogger.Warn("AzureEventHubTarget(Name={0}): EventHubClient connection still closing after {1}; continuing shutdown", Name, ConnectionCloseTimeout);
+                }
+            }
+            catch (Exception ex)
+            {
+                InternalLogger.Warn(ex, "AzureEventHubTarget(Name={0}): Failed to close EventHubClient connection during shutdown", Name);
+            }
         }
 
         /// <summary>

--- a/src/NLog.Extensions.AzureEventHub/EventHubTarget.cs
+++ b/src/NLog.Extensions.AzureEventHub/EventHubTarget.cs
@@ -313,13 +313,6 @@ namespace NLog.Targets
             }
         }
 
-        // Upper bound on how long shutdown blocks waiting for the connection to close. Generous
-        // enough for a healthy-but-slow teardown (the old hard 500ms cap truncated those), yet
-        // bounded so a hung SDK close cannot stall process shutdown. On timeout the close is not
-        // abandoned: its outcome is still observed asynchronously so a later fault never becomes an
-        // unobserved task exception.
-        private static readonly TimeSpan ConnectionCloseTimeout = TimeSpan.FromSeconds(5);
-
         /// <summary>
         /// Closes the target and releases any unmanaged resources.
         /// </summary>
@@ -333,41 +326,7 @@ namespace NLog.Targets
             }
             finally
             {
-                CloseConnection();
-            }
-        }
-
-        private void CloseConnection()
-        {
-            try
-            {
-                var closeTask = Task.Run(() => _eventHubService.CloseAsync());
-
-                bool completed;
-                try
-                {
-                    completed = closeTask.Wait(ConnectionCloseTimeout);
-                }
-                catch (Exception ex)
-                {
-                    // CloseAsync faulted within the wait window - observed here, logged, not rethrown.
-                    InternalLogger.Warn(ex.GetBaseException(), "AzureEventHubTarget(Name={0}): Failed to close EventHubClient connection during shutdown", Name);
-                    return;
-                }
-
-                if (!completed)
-                {
-                    // Still closing after the bound: observe the eventual outcome so a later fault is
-                    // never an unobserved task exception, and surface it via InternalLogger.
-                    closeTask.ContinueWith(
-                        t => InternalLogger.Warn(t.Exception?.GetBaseException(), "AzureEventHubTarget(Name={0}): Failed to close EventHubClient connection during shutdown", Name),
-                        CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-                    InternalLogger.Warn("AzureEventHubTarget(Name={0}): EventHubClient connection still closing after {1}; continuing shutdown", Name, ConnectionCloseTimeout);
-                }
-            }
-            catch (Exception ex)
-            {
-                InternalLogger.Warn(ex, "AzureEventHubTarget(Name={0}): Failed to close EventHubClient connection during shutdown", Name);
+                AsyncTargetCloseHelper.CloseConnection(_eventHubService.CloseAsync, "AzureEventHubTarget", "EventHubClient", Name);
             }
         }
 

--- a/src/NLog.Extensions.AzureEventHub/NLog.Extensions.AzureEventHub.csproj
+++ b/src/NLog.Extensions.AzureEventHub/NLog.Extensions.AzureEventHub.csproj
@@ -36,6 +36,7 @@ Docs: https://github.com/JDetmar/NLog.Extensions.AzureStorage/blob/master/src/NL
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\NLog.Extensions.AzureStorage\AsyncTargetCloseHelper.cs" Link="AsyncTargetCloseHelper.cs" />
     <Compile Include="..\NLog.Extensions.AzureStorage\AzureCredentialHelper.cs" Link="AzureCredentialHelper.cs" />
     <Compile Include="..\NLog.Extensions.AzureStorage\ProxyHelpers.cs" Link="ProxyHelpers.cs" />
     <Compile Include="..\NLog.Extensions.AzureStorage\SortHelpers.cs" Link="SortHelpers.cs" />

--- a/src/NLog.Extensions.AzureServiceBus/NLog.Extensions.AzureServiceBus.csproj
+++ b/src/NLog.Extensions.AzureServiceBus/NLog.Extensions.AzureServiceBus.csproj
@@ -36,6 +36,7 @@ Docs: https://github.com/JDetmar/NLog.Extensions.AzureStorage/blob/master/src/NL
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\NLog.Extensions.AzureStorage\AsyncTargetCloseHelper.cs" Link="AsyncTargetCloseHelper.cs" />
     <Compile Include="..\NLog.Extensions.AzureStorage\AzureCredentialHelper.cs" Link="AzureCredentialHelper.cs" />
     <Compile Include="..\NLog.Extensions.AzureStorage\AzureStorageNameCache.cs" Link="AzureStorageNameCache.cs" />
     <Compile Include="..\NLog.Extensions.AzureStorage\ProxyHelpers.cs" Link="ProxyHelpers.cs" />

--- a/src/NLog.Extensions.AzureServiceBus/ServiceBusTarget.cs
+++ b/src/NLog.Extensions.AzureServiceBus/ServiceBusTarget.cs
@@ -388,13 +388,6 @@ namespace NLog.Targets
             return default(TimeSpan?);
         }
 
-        // Upper bound on how long shutdown blocks waiting for the connection to close. Generous
-        // enough for a healthy-but-slow teardown (the old hard 500ms cap truncated those), yet
-        // bounded so a hung SDK close cannot stall process shutdown. On timeout the close is not
-        // abandoned: its outcome is still observed asynchronously so a later fault never becomes an
-        // unobserved task exception (and the client is not left undisposed unnoticed).
-        private static readonly TimeSpan ConnectionCloseTimeout = TimeSpan.FromSeconds(5);
-
         /// <inheritdoc />
         protected override void CloseTarget()
         {
@@ -406,41 +399,7 @@ namespace NLog.Targets
             }
             finally
             {
-                CloseConnection();
-            }
-        }
-
-        private void CloseConnection()
-        {
-            try
-            {
-                var closeTask = Task.Run(() => _cloudServiceBus.CloseAsync());
-
-                bool completed;
-                try
-                {
-                    completed = closeTask.Wait(ConnectionCloseTimeout);
-                }
-                catch (Exception ex)
-                {
-                    // CloseAsync faulted within the wait window - observed here, logged, not rethrown.
-                    InternalLogger.Warn(ex.GetBaseException(), "AzureServiceBusTarget(Name={0}): Failed to close ServiceBusClient connection during shutdown", Name);
-                    return;
-                }
-
-                if (!completed)
-                {
-                    // Still closing after the bound: observe the eventual outcome so a later fault is
-                    // never an unobserved task exception, and surface it via InternalLogger.
-                    closeTask.ContinueWith(
-                        t => InternalLogger.Warn(t.Exception?.GetBaseException(), "AzureServiceBusTarget(Name={0}): Failed to close ServiceBusClient connection during shutdown", Name),
-                        CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
-                    InternalLogger.Warn("AzureServiceBusTarget(Name={0}): ServiceBusClient connection still closing after {1}; continuing shutdown", Name, ConnectionCloseTimeout);
-                }
-            }
-            catch (Exception ex)
-            {
-                InternalLogger.Warn(ex, "AzureServiceBusTarget(Name={0}): Failed to close ServiceBusClient connection during shutdown", Name);
+                AsyncTargetCloseHelper.CloseConnection(_cloudServiceBus.CloseAsync, "AzureServiceBusTarget", "ServiceBusClient", Name);
             }
         }
 

--- a/src/NLog.Extensions.AzureServiceBus/ServiceBusTarget.cs
+++ b/src/NLog.Extensions.AzureServiceBus/ServiceBusTarget.cs
@@ -388,12 +388,60 @@ namespace NLog.Targets
             return default(TimeSpan?);
         }
 
+        // Upper bound on how long shutdown blocks waiting for the connection to close. Generous
+        // enough for a healthy-but-slow teardown (the old hard 500ms cap truncated those), yet
+        // bounded so a hung SDK close cannot stall process shutdown. On timeout the close is not
+        // abandoned: its outcome is still observed asynchronously so a later fault never becomes an
+        // unobserved task exception (and the client is not left undisposed unnoticed).
+        private static readonly TimeSpan ConnectionCloseTimeout = TimeSpan.FromSeconds(5);
+
         /// <inheritdoc />
         protected override void CloseTarget()
         {
-            var task = Task.Run(async () => await _cloudServiceBus.CloseAsync().ConfigureAwait(false));
-            task.Wait(TimeSpan.FromMilliseconds(500));
-            base.CloseTarget();
+            try
+            {
+                // Let NLog drain any remaining queued events over the still-open connection first,
+                // then close the connection - never the other way around.
+                base.CloseTarget();
+            }
+            finally
+            {
+                CloseConnection();
+            }
+        }
+
+        private void CloseConnection()
+        {
+            try
+            {
+                var closeTask = Task.Run(() => _cloudServiceBus.CloseAsync());
+
+                bool completed;
+                try
+                {
+                    completed = closeTask.Wait(ConnectionCloseTimeout);
+                }
+                catch (Exception ex)
+                {
+                    // CloseAsync faulted within the wait window - observed here, logged, not rethrown.
+                    InternalLogger.Warn(ex.GetBaseException(), "AzureServiceBusTarget(Name={0}): Failed to close ServiceBusClient connection during shutdown", Name);
+                    return;
+                }
+
+                if (!completed)
+                {
+                    // Still closing after the bound: observe the eventual outcome so a later fault is
+                    // never an unobserved task exception, and surface it via InternalLogger.
+                    closeTask.ContinueWith(
+                        t => InternalLogger.Warn(t.Exception?.GetBaseException(), "AzureServiceBusTarget(Name={0}): Failed to close ServiceBusClient connection during shutdown", Name),
+                        CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+                    InternalLogger.Warn("AzureServiceBusTarget(Name={0}): ServiceBusClient connection still closing after {1}; continuing shutdown", Name, ConnectionCloseTimeout);
+                }
+            }
+            catch (Exception ex)
+            {
+                InternalLogger.Warn(ex, "AzureServiceBusTarget(Name={0}): Failed to close ServiceBusClient connection during shutdown", Name);
+            }
         }
 
         /// <inheritdoc />

--- a/src/NLog.Extensions.AzureStorage/AsyncTargetCloseHelper.cs
+++ b/src/NLog.Extensions.AzureStorage/AsyncTargetCloseHelper.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NLog.Common;
+
+namespace NLog.Extensions.AzureStorage
+{
+    /// <summary>
+    /// Shared sync-over-async bridge for closing an Azure SDK client connection from a target's
+    /// synchronous <c>CloseTarget</c> during NLog shutdown. The close outcome is always observed -
+    /// a fault is surfaced via <see cref="InternalLogger"/> and never becomes an unobserved task
+    /// exception - the wait is bounded so a hung close cannot stall shutdown, and it never throws.
+    /// </summary>
+    internal static class AsyncTargetCloseHelper
+    {
+        // Upper bound on how long shutdown blocks waiting for the connection to close. Generous
+        // enough for a healthy-but-slow teardown (an over-tight cap truncates those), yet bounded so
+        // a hung SDK close cannot stall process shutdown. On timeout the close is not abandoned: its
+        // outcome is still observed asynchronously, so a later fault never goes unnoticed.
+        private static readonly TimeSpan ConnectionCloseTimeout = TimeSpan.FromSeconds(5);
+
+        /// <summary>
+        /// Runs <paramref name="closeAsync"/> on the thread pool and waits up to the bounded timeout,
+        /// observing and logging any fault. Returns normally even on failure so a target's shutdown
+        /// can never be broken by a connection close.
+        /// </summary>
+        public static void CloseConnection(Func<Task> closeAsync, string targetType, string clientName, string targetName)
+        {
+            try
+            {
+                var closeTask = Task.Run(closeAsync);
+                if (!closeTask.Wait(ConnectionCloseTimeout))
+                {
+                    // Still closing after the bound: observe the eventual outcome so a later fault is
+                    // never an unobserved task exception, and surface it via InternalLogger.
+                    closeTask.ContinueWith(
+                        t => InternalLogger.Warn(t.Exception?.GetBaseException(), "{0}(Name={1}): Failed to close {2} connection during shutdown", targetType, targetName, clientName),
+                        CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+                    InternalLogger.Warn("{0}(Name={1}): {2} connection still closing after {3}; continuing shutdown", targetType, targetName, clientName, ConnectionCloseTimeout);
+                }
+            }
+            catch (Exception ex)
+            {
+                // CloseAsync faulted within the wait window (Wait rethrows it) or could not be started -
+                // observed here and logged, never rethrown so shutdown cannot fail.
+                InternalLogger.Warn(ex.GetBaseException(), "{0}(Name={1}): Failed to close {2} connection during shutdown", targetType, targetName, clientName);
+            }
+        }
+    }
+}

--- a/test/NLog.Extensions.AzureEventHub.Tests/EventHubShutdownTests.cs
+++ b/test/NLog.Extensions.AzureEventHub.Tests/EventHubShutdownTests.cs
@@ -14,6 +14,7 @@ namespace NLog.Extensions.AzureEventHub.Test
     /// propagate out of shutdown, and a legitimately slow close must be awaited rather than
     /// abandoned by an over-tight timeout. Events must be flushed before the connection is closed.
     /// </summary>
+    [Collection("InternalLogger isolation")]
     public class EventHubShutdownTests
     {
         private static (LogFactory, RecordingEventHubService) BuildTarget(int taskDelayMs = 1)

--- a/test/NLog.Extensions.AzureEventHub.Tests/EventHubShutdownTests.cs
+++ b/test/NLog.Extensions.AzureEventHub.Tests/EventHubShutdownTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using NLog;
+using NLog.Common;
+using NLog.Config;
+using NLog.Targets;
+using Xunit;
+
+namespace NLog.Extensions.AzureEventHub.Test
+{
+    /// <summary>
+    /// Regression tests for the S5 shutdown-teardown behaviour of <see cref="EventHubTarget"/>:
+    /// the connection close must be observed (never a silent unobserved task exception), must not
+    /// propagate out of shutdown, and a legitimately slow close must be awaited rather than
+    /// abandoned by an over-tight timeout. Events must be flushed before the connection is closed.
+    /// </summary>
+    public class EventHubShutdownTests
+    {
+        private static (LogFactory, RecordingEventHubService) BuildTarget(int taskDelayMs = 1)
+        {
+            var svc = new RecordingEventHubService();
+            var logFactory = new LogFactory();
+            var logConfig = new LoggingConfiguration(logFactory);
+            var target = new EventHubTarget(svc)
+            {
+                ConnectionString = "LocalEventHub",
+                EventHubName = "hub",
+                PartitionKey = "${logger}",
+                Layout = "${message}",
+                TaskDelayMilliseconds = taskDelayMs,
+                BatchSize = 1000,
+            };
+            logConfig.AddRuleForAllLevels(target);
+            logFactory.Configuration = logConfig;
+            return (logFactory, svc);
+        }
+
+        [Fact]
+        public void Shutdown_FlushesQueuedEventsBeforeClosingConnection()
+        {
+            // Big TaskDelay keeps events queued so shutdown is responsible for draining them.
+            var (logFactory, svc) = BuildTarget(taskDelayMs: 10000);
+            var logger = logFactory.GetLogger("P");
+            for (int i = 0; i < 5; ++i)
+                logger.Info("msg" + i);
+
+            logFactory.Shutdown();
+
+            Assert.Equal(5, svc.SendCount);             // nothing dropped on shutdown
+            Assert.Equal(0, svc.SendAfterCloseCount);   // nothing sent over a closed connection
+            Assert.Equal(1, svc.CloseCompletedCount);
+        }
+
+        [Fact]
+        public void Shutdown_WhenCloseAsyncThrows_IsLoggedAndDoesNotPropagate()
+        {
+            var buffer = new StringWriter();
+            var prevWriter = InternalLogger.LogWriter;
+            var prevLevel = InternalLogger.LogLevel;
+            InternalLogger.LogWriter = TextWriter.Synchronized(buffer);
+            InternalLogger.LogLevel = LogLevel.Trace;
+            try
+            {
+                var (logFactory, svc) = BuildTarget();
+                svc.CloseDelay = TimeSpan.FromMilliseconds(900); // faults well after the old 500ms cap
+                svc.CloseThrows = true;
+                logFactory.GetLogger("P").Info("hello");
+                logFactory.Flush();
+
+                var ex = Record.Exception(() => logFactory.Shutdown());
+
+                Assert.Null(ex);   // shutdown must never throw because the connection close failed
+            }
+            finally
+            {
+                InternalLogger.LogWriter = prevWriter;
+                InternalLogger.LogLevel = prevLevel;
+            }
+
+            // The close failure must be observed and surfaced (not a silent unobserved task exception).
+            string internalLog;
+            lock (buffer)
+                internalLog = buffer.ToString();
+            Assert.Contains("EventHubClient connection during shutdown", internalLog, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Shutdown_SlowCloseIsAwaitedNotAbandoned()
+        {
+            var (logFactory, svc) = BuildTarget();
+            svc.CloseDelay = TimeSpan.FromMilliseconds(800); // slower than the old 500ms cap, well within the new bound
+            logFactory.GetLogger("P").Info("hello");
+            logFactory.Flush();
+
+            logFactory.Shutdown();
+
+            // The connection close (and, for ServiceBus, the client dispose) must run to completion
+            // during shutdown rather than being abandoned mid-flight by an over-tight timeout.
+            Assert.True(svc.ConnectionClosed, "CloseAsync was abandoned before it completed");
+            Assert.Equal(1, svc.CloseCompletedCount);
+        }
+    }
+}

--- a/test/NLog.Extensions.AzureEventHub.Tests/RecordingEventHubService.cs
+++ b/test/NLog.Extensions.AzureEventHub.Tests/RecordingEventHubService.cs
@@ -1,0 +1,119 @@
+using Azure.Messaging.EventHubs;
+using NLog.Extensions.AzureBlobStorage;
+using NLog.Extensions.AzureStorage;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NLog.Extensions.AzureEventHub.Test
+{
+    /// <summary>
+    /// Instrumented <see cref="IEventHubService"/> that records the ORDER of batch sends
+    /// relative to <see cref="CloseAsync"/>, and can make CloseAsync slow and/or throw on
+    /// demand. Used to reproduce and regression-test the S5 shutdown-teardown behaviour.
+    /// </summary>
+    sealed class RecordingEventHubService : IEventHubService
+    {
+        private readonly object _sync = new object();
+
+        public List<string> Timeline { get; } = new List<string>();
+        public int SendCount;
+        public int SendAfterCloseCount;
+        public int CloseStartedCount;
+        public int CloseCompletedCount;
+
+        /// <summary>True once CloseAsync has fully completed (connection closed).</summary>
+        public volatile bool ConnectionClosed;
+
+        public TimeSpan CloseDelay { get; set; } = TimeSpan.Zero;
+        public bool CloseThrows { get; set; }
+
+        public string EventHubName => "recording";
+
+        public void Connect(string connectionString, string eventHubName, string serviceUri, string tenantIdentity, string managedIdentityResourceId, string managedIdentityClientId, string sharedAccessSignature, string storageAccountName, string storageAccountAccessKey, string clientAuthId, string clientAuthSecret, string eventProducerIdentifier, bool useWebSockets, string endPointAddress, ProxySettings proxySettings)
+        {
+        }
+
+        public async Task CloseAsync()
+        {
+            lock (_sync)
+            {
+                Timeline.Add("close:start");
+                CloseStartedCount++;
+            }
+
+            if (CloseDelay > TimeSpan.Zero)
+                await Task.Delay(CloseDelay).ConfigureAwait(false);
+
+            if (CloseThrows)
+            {
+                lock (_sync)
+                    Timeline.Add("close:throw");
+                throw new InvalidOperationException("RecordingEventHubService.CloseAsync boom");
+            }
+
+            ConnectionClosed = true;
+            lock (_sync)
+            {
+                Timeline.Add("close:end");
+                CloseCompletedCount++;
+            }
+        }
+
+        public Task<IEventDataBatch> CreateBatchAsync(string partitionKey, int maxBatchSizeBytes, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IEventDataBatch>(new RecordingBatch(this, partitionKey ?? string.Empty));
+        }
+
+        private void RecordSend(string partitionKey, int count)
+        {
+            lock (_sync)
+            {
+                bool afterClose = ConnectionClosed;
+                Timeline.Add($"send:{partitionKey}:{count}{(afterClose ? ":AFTER-CLOSE" : "")}");
+                SendCount += count;
+                if (afterClose)
+                    SendAfterCloseCount += count;
+            }
+        }
+
+        public string DumpTimeline()
+        {
+            lock (_sync)
+                return string.Join(" | ", Timeline);
+        }
+
+        private sealed class RecordingBatch : IEventDataBatch
+        {
+            private readonly RecordingEventHubService _owner;
+            private readonly string _partitionKey;
+            private readonly List<EventData> _events = new List<EventData>();
+
+            public RecordingBatch(RecordingEventHubService owner, string partitionKey)
+            {
+                _owner = owner;
+                _partitionKey = partitionKey;
+            }
+
+            public int Count => _events.Count;
+            public long MaximumSizeInBytes => long.MaxValue;
+
+            public bool TryAddEvent(EventData eventData)
+            {
+                _events.Add(eventData);
+                return true;
+            }
+
+            public Task SendAsync(CancellationToken cancellationToken)
+            {
+                _owner.RecordSend(_partitionKey, _events.Count);
+                return Task.CompletedTask;
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/test/NLog.Extensions.AzureEventHub.Tests/RecordingEventHubService.cs
+++ b/test/NLog.Extensions.AzureEventHub.Tests/RecordingEventHubService.cs
@@ -9,18 +9,16 @@ using System.Threading.Tasks;
 namespace NLog.Extensions.AzureEventHub.Test
 {
     /// <summary>
-    /// Instrumented <see cref="IEventHubService"/> that records the ORDER of batch sends
-    /// relative to <see cref="CloseAsync"/>, and can make CloseAsync slow and/or throw on
-    /// demand. Used to reproduce and regression-test the S5 shutdown-teardown behaviour.
+    /// Instrumented <see cref="IEventHubService"/> that counts batch sends relative to
+    /// <see cref="CloseAsync"/>, and can make CloseAsync slow and/or throw on demand. Used to
+    /// reproduce and regression-test the S5 shutdown-teardown behaviour.
     /// </summary>
     sealed class RecordingEventHubService : IEventHubService
     {
         private readonly object _sync = new object();
 
-        public List<string> Timeline { get; } = new List<string>();
         public int SendCount;
         public int SendAfterCloseCount;
-        public int CloseStartedCount;
         public int CloseCompletedCount;
 
         /// <summary>True once CloseAsync has fully completed (connection closed).</summary>
@@ -37,63 +35,40 @@ namespace NLog.Extensions.AzureEventHub.Test
 
         public async Task CloseAsync()
         {
-            lock (_sync)
-            {
-                Timeline.Add("close:start");
-                CloseStartedCount++;
-            }
-
             if (CloseDelay > TimeSpan.Zero)
                 await Task.Delay(CloseDelay).ConfigureAwait(false);
 
             if (CloseThrows)
-            {
-                lock (_sync)
-                    Timeline.Add("close:throw");
                 throw new InvalidOperationException("RecordingEventHubService.CloseAsync boom");
-            }
 
             ConnectionClosed = true;
             lock (_sync)
-            {
-                Timeline.Add("close:end");
                 CloseCompletedCount++;
-            }
         }
 
         public Task<IEventDataBatch> CreateBatchAsync(string partitionKey, int maxBatchSizeBytes, CancellationToken cancellationToken)
         {
-            return Task.FromResult<IEventDataBatch>(new RecordingBatch(this, partitionKey ?? string.Empty));
+            return Task.FromResult<IEventDataBatch>(new RecordingBatch(this));
         }
 
-        private void RecordSend(string partitionKey, int count)
+        private void RecordSend(int count)
         {
             lock (_sync)
             {
-                bool afterClose = ConnectionClosed;
-                Timeline.Add($"send:{partitionKey}:{count}{(afterClose ? ":AFTER-CLOSE" : "")}");
                 SendCount += count;
-                if (afterClose)
+                if (ConnectionClosed)
                     SendAfterCloseCount += count;
             }
-        }
-
-        public string DumpTimeline()
-        {
-            lock (_sync)
-                return string.Join(" | ", Timeline);
         }
 
         private sealed class RecordingBatch : IEventDataBatch
         {
             private readonly RecordingEventHubService _owner;
-            private readonly string _partitionKey;
             private readonly List<EventData> _events = new List<EventData>();
 
-            public RecordingBatch(RecordingEventHubService owner, string partitionKey)
+            public RecordingBatch(RecordingEventHubService owner)
             {
                 _owner = owner;
-                _partitionKey = partitionKey;
             }
 
             public int Count => _events.Count;
@@ -107,7 +82,7 @@ namespace NLog.Extensions.AzureEventHub.Test
 
             public Task SendAsync(CancellationToken cancellationToken)
             {
-                _owner.RecordSend(_partitionKey, _events.Count);
+                _owner.RecordSend(_events.Count);
                 return Task.CompletedTask;
             }
 

--- a/test/NLog.Extensions.AzureServiceBus.Tests/RecordingCloudServiceBus.cs
+++ b/test/NLog.Extensions.AzureServiceBus.Tests/RecordingCloudServiceBus.cs
@@ -9,8 +9,8 @@ using NLog.Extensions.AzureStorage;
 namespace NLog.Extensions.AzureServiceBus.Test
 {
     /// <summary>
-    /// Instrumented <see cref="ICloudServiceBus"/> that records the ORDER of batch sends relative
-    /// to <see cref="CloseAsync"/>, and can make CloseAsync slow and/or throw on demand. Models the
+    /// Instrumented <see cref="ICloudServiceBus"/> that counts batch sends relative to
+    /// <see cref="CloseAsync"/>, and can make CloseAsync slow and/or throw on demand. Models the
     /// real CloseAsync that closes the sender and then disposes the client, so a test can assert the
     /// client dispose is awaited (not abandoned). Used to reproduce/regression-test the S5 teardown.
     /// </summary>
@@ -18,10 +18,8 @@ namespace NLog.Extensions.AzureServiceBus.Test
     {
         private readonly object _sync = new object();
 
-        public List<string> Timeline { get; } = new List<string>();
         public int SendCount;
         public int SendAfterCloseCount;
-        public int CloseStartedCount;
         public int CloseCompletedCount;
 
         /// <summary>True once the sender has been closed.</summary>
@@ -41,36 +39,20 @@ namespace NLog.Extensions.AzureServiceBus.Test
 
         public async Task CloseAsync()
         {
-            lock (_sync)
-            {
-                Timeline.Add("close:start");
-                CloseStartedCount++;
-            }
-
             if (CloseDelay > TimeSpan.Zero)
                 await Task.Delay(CloseDelay).ConfigureAwait(false);
 
             if (CloseThrows)
-            {
-                lock (_sync)
-                    Timeline.Add("close:throw");
                 throw new InvalidOperationException("RecordingCloudServiceBus.CloseAsync boom");
-            }
 
             ConnectionClosed = true;    // _sender.CloseAsync()
             DisposeCompleted = true;    // _client.DisposeAsync()
             lock (_sync)
-            {
-                Timeline.Add("close:end");
                 CloseCompletedCount++;
-            }
         }
 
         public Task<IServiceBusMessageBatch> CreateMessageBatchAsync(int maxBatchSizeBytes, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(EntityPath))
-                throw new InvalidOperationException("ServiceBusService not connected");
-
             return Task.FromResult<IServiceBusMessageBatch>(new RecordingBatch(this));
         }
 
@@ -78,18 +60,10 @@ namespace NLog.Extensions.AzureServiceBus.Test
         {
             lock (_sync)
             {
-                bool afterClose = ConnectionClosed;
-                Timeline.Add($"send:{count}{(afterClose ? ":AFTER-CLOSE" : "")}");
                 SendCount += count;
-                if (afterClose)
+                if (ConnectionClosed)
                     SendAfterCloseCount += count;
             }
-        }
-
-        public string DumpTimeline()
-        {
-            lock (_sync)
-                return string.Join(" | ", Timeline);
         }
 
         private sealed class RecordingBatch : IServiceBusMessageBatch

--- a/test/NLog.Extensions.AzureServiceBus.Tests/RecordingCloudServiceBus.cs
+++ b/test/NLog.Extensions.AzureServiceBus.Tests/RecordingCloudServiceBus.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+using NLog.Extensions.AzureBlobStorage;
+using NLog.Extensions.AzureStorage;
+
+namespace NLog.Extensions.AzureServiceBus.Test
+{
+    /// <summary>
+    /// Instrumented <see cref="ICloudServiceBus"/> that records the ORDER of batch sends relative
+    /// to <see cref="CloseAsync"/>, and can make CloseAsync slow and/or throw on demand. Models the
+    /// real CloseAsync that closes the sender and then disposes the client, so a test can assert the
+    /// client dispose is awaited (not abandoned). Used to reproduce/regression-test the S5 teardown.
+    /// </summary>
+    sealed class RecordingCloudServiceBus : ICloudServiceBus
+    {
+        private readonly object _sync = new object();
+
+        public List<string> Timeline { get; } = new List<string>();
+        public int SendCount;
+        public int SendAfterCloseCount;
+        public int CloseStartedCount;
+        public int CloseCompletedCount;
+
+        /// <summary>True once the sender has been closed.</summary>
+        public volatile bool ConnectionClosed;
+        /// <summary>True once the client has been disposed (the step that leaks if abandoned).</summary>
+        public volatile bool DisposeCompleted;
+
+        public TimeSpan CloseDelay { get; set; } = TimeSpan.Zero;
+        public bool CloseThrows { get; set; }
+
+        public string EntityPath => "recording";
+        public TimeSpan? DefaultTimeToLive => null;
+
+        public void Connect(string connectionString, string queueOrTopicName, string serviceUri, string tenantIdentity, string managedIdentityResourceId, string managedIdentityClientId, string sharedAccessSignature, string storageAccountName, string storageAccountAccessKey, string clientAuthId, string clientAuthSecret, string eventProducerIdentifier, bool useWebSockets, string endPointAddress, TimeSpan? timeToLive, ProxySettings proxySettings)
+        {
+        }
+
+        public async Task CloseAsync()
+        {
+            lock (_sync)
+            {
+                Timeline.Add("close:start");
+                CloseStartedCount++;
+            }
+
+            if (CloseDelay > TimeSpan.Zero)
+                await Task.Delay(CloseDelay).ConfigureAwait(false);
+
+            if (CloseThrows)
+            {
+                lock (_sync)
+                    Timeline.Add("close:throw");
+                throw new InvalidOperationException("RecordingCloudServiceBus.CloseAsync boom");
+            }
+
+            ConnectionClosed = true;    // _sender.CloseAsync()
+            DisposeCompleted = true;    // _client.DisposeAsync()
+            lock (_sync)
+            {
+                Timeline.Add("close:end");
+                CloseCompletedCount++;
+            }
+        }
+
+        public Task<IServiceBusMessageBatch> CreateMessageBatchAsync(int maxBatchSizeBytes, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(EntityPath))
+                throw new InvalidOperationException("ServiceBusService not connected");
+
+            return Task.FromResult<IServiceBusMessageBatch>(new RecordingBatch(this));
+        }
+
+        private void RecordSend(int count)
+        {
+            lock (_sync)
+            {
+                bool afterClose = ConnectionClosed;
+                Timeline.Add($"send:{count}{(afterClose ? ":AFTER-CLOSE" : "")}");
+                SendCount += count;
+                if (afterClose)
+                    SendAfterCloseCount += count;
+            }
+        }
+
+        public string DumpTimeline()
+        {
+            lock (_sync)
+                return string.Join(" | ", Timeline);
+        }
+
+        private sealed class RecordingBatch : IServiceBusMessageBatch
+        {
+            private readonly RecordingCloudServiceBus _owner;
+            private readonly List<ServiceBusMessage> _messages = new List<ServiceBusMessage>();
+
+            public RecordingBatch(RecordingCloudServiceBus owner)
+            {
+                _owner = owner;
+            }
+
+            public int Count => _messages.Count;
+            public long MaximumSizeInBytes => long.MaxValue;
+
+            public bool TryAddMessage(ServiceBusMessage message)
+            {
+                _messages.Add(message);
+                return true;
+            }
+
+            public Task SendAsync(CancellationToken cancellationToken)
+            {
+                _owner.RecordSend(_messages.Count);
+                return Task.CompletedTask;
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/test/NLog.Extensions.AzureServiceBus.Tests/ServiceBusShutdownTests.cs
+++ b/test/NLog.Extensions.AzureServiceBus.Tests/ServiceBusShutdownTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using NLog;
+using NLog.Common;
+using NLog.Config;
+using NLog.Targets;
+using Xunit;
+
+namespace NLog.Extensions.AzureServiceBus.Test
+{
+    /// <summary>
+    /// Regression tests for the S5 shutdown-teardown behaviour of <see cref="ServiceBusTarget"/>:
+    /// the connection close (sender close + client dispose) must be observed (never a silent
+    /// unobserved task exception), must not propagate out of shutdown, and a legitimately slow
+    /// close must be awaited rather than abandoned by an over-tight timeout (which would also leak
+    /// the undisposed client). Events must be flushed before the connection is closed.
+    /// </summary>
+    public class ServiceBusShutdownTests
+    {
+        private static (LogFactory, RecordingCloudServiceBus) BuildTarget(int taskDelayMs = 1)
+        {
+            var svc = new RecordingCloudServiceBus();
+            var logFactory = new LogFactory();
+            var logConfig = new LoggingConfiguration(logFactory);
+            var target = new ServiceBusTarget(svc)
+            {
+                ConnectionString = "LocalServiceBus",
+                QueueName = "q",
+                PartitionKey = "${logger}",
+                Layout = "${message}",
+                TaskDelayMilliseconds = taskDelayMs,
+                BatchSize = 1000,
+            };
+            logConfig.AddRuleForAllLevels(target);
+            logFactory.Configuration = logConfig;
+            return (logFactory, svc);
+        }
+
+        [Fact]
+        public void Shutdown_FlushesQueuedEventsBeforeClosingConnection()
+        {
+            var (logFactory, svc) = BuildTarget(taskDelayMs: 10000);
+            var logger = logFactory.GetLogger("P");
+            for (int i = 0; i < 5; ++i)
+                logger.Info("msg" + i);
+
+            logFactory.Shutdown();
+
+            Assert.Equal(5, svc.SendCount);             // nothing dropped on shutdown
+            Assert.Equal(0, svc.SendAfterCloseCount);   // nothing sent over a closed connection
+            Assert.Equal(1, svc.CloseCompletedCount);
+        }
+
+        [Fact]
+        public void Shutdown_WhenCloseAsyncThrows_IsLoggedAndDoesNotPropagate()
+        {
+            var buffer = new StringWriter();
+            var prevWriter = InternalLogger.LogWriter;
+            var prevLevel = InternalLogger.LogLevel;
+            InternalLogger.LogWriter = TextWriter.Synchronized(buffer);
+            InternalLogger.LogLevel = LogLevel.Trace;
+            try
+            {
+                var (logFactory, svc) = BuildTarget();
+                svc.CloseDelay = TimeSpan.FromMilliseconds(900); // faults well after the old 500ms cap
+                svc.CloseThrows = true;
+                logFactory.GetLogger("P").Info("hello");
+                logFactory.Flush();
+
+                var ex = Record.Exception(() => logFactory.Shutdown());
+
+                Assert.Null(ex);   // shutdown must never throw because the connection close failed
+            }
+            finally
+            {
+                InternalLogger.LogWriter = prevWriter;
+                InternalLogger.LogLevel = prevLevel;
+            }
+
+            string internalLog;
+            lock (buffer)
+                internalLog = buffer.ToString();
+            Assert.Contains("ServiceBusClient connection during shutdown", internalLog, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Shutdown_SlowCloseIsAwaitedNotAbandoned()
+        {
+            var (logFactory, svc) = BuildTarget();
+            svc.CloseDelay = TimeSpan.FromMilliseconds(800); // slower than the old 500ms cap, well within the new bound
+            logFactory.GetLogger("P").Info("hello");
+            logFactory.Flush();
+
+            logFactory.Shutdown();
+
+            // Both the sender close and the client dispose must run to completion during shutdown
+            // rather than being abandoned mid-flight (an abandoned DisposeAsync leaks the client).
+            Assert.True(svc.ConnectionClosed, "CloseAsync was abandoned before it completed");
+            Assert.True(svc.DisposeCompleted, "ServiceBusClient was not disposed (dispose abandoned)");
+            Assert.Equal(1, svc.CloseCompletedCount);
+        }
+    }
+}

--- a/test/NLog.Extensions.AzureServiceBus.Tests/ServiceBusShutdownTests.cs
+++ b/test/NLog.Extensions.AzureServiceBus.Tests/ServiceBusShutdownTests.cs
@@ -15,6 +15,7 @@ namespace NLog.Extensions.AzureServiceBus.Test
     /// close must be awaited rather than abandoned by an over-tight timeout (which would also leak
     /// the undisposed client). Events must be flushed before the connection is closed.
     /// </summary>
+    [Collection("InternalLogger isolation")]
     public class ServiceBusShutdownTests
     {
         private static (LogFactory, RecordingCloudServiceBus) BuildTarget(int taskDelayMs = 1)


### PR DESCRIPTION
## S5 — shutdown teardown on `EventHubTarget` / `ServiceBusTarget`

The audit (BUGHUNT.md, S5 remainder) flagged this as *"shutdown log loss (flush abandoned)"*. **Reproducing before writing tests corrected that premise.** The headline "log loss" does **not** happen; two adjacent defects do.

Both targets had:

```csharp
protected override void CloseTarget()
{
    var task = Task.Run(async () => await _xService.CloseAsync().ConfigureAwait(false));
    task.Wait(TimeSpan.FromMilliseconds(500));   // bool result discarded
    base.CloseTarget();
}
```

`CloseAsync()` closes the **connection** (EventHub `_client.CloseAsync()`; ServiceBus `_sender.CloseAsync()` then `_client.DisposeAsync()`), **not** the NLog queue — draining the queue is `AsyncTaskTarget`'s job (neither target overrides `FlushAsync`). The connection was closed *before* `base.CloseTarget()`.

## Reproduction (instrumented fakes + `LogFactory`)

I added recording `IEventHubService` / `ICloudServiceBus` fakes that log the order of batch sends relative to `CloseAsync`, and can make `CloseAsync` slow and/or throw. Findings on `origin/master`:

| # | Question | Result |
|---|----------|--------|
| 1 | Does NLog flush before or after `CloseTarget`? Any send over a closed client? | **Flushes BEFORE** `CloseTarget` in every shutdown path (`Shutdown()`, `Configuration = null`, `Dispose()`). Timeline: `send | close:start | close:end`. **Zero** sends after close. → the *"log loss / send over closed client"* premise is **disproven**. |
| 2 | `CloseAsync` throws *after* the 500 ms wait elapses — observed anywhere? | **Silent unobserved `TaskException`** (confirmed: `UnobservedTaskException` fired once, nothing in the internal log). **Real defect.** |
| 3 | `CloseAsync` throws *within* 500 ms — does `Wait` rethrow out of `CloseTarget`? | Shutdown does **not** propagate it — NLog's `Target.Close()` already swallows `CloseTarget` exceptions. Throwing an `AggregateException` out of `CloseTarget` is still poor form and gets logged as a scary error. |
| 4 | Slow (800 ms) successful close — awaited or abandoned? | **Abandoned** at the 500 ms cap (`shutdownMs≈502`, connection still closing). For ServiceBus the abandoned step is `_client.DisposeAsync()` → **leaked client**. **Real defect.** |

## Fix (symmetric across both targets)

- **Drain, then close.** Call `base.CloseTarget()` first so NLog flushes any remaining queued events over the still-open connection, *then* close the connection — never the reverse. (Defensive: repro showed NLog already flushes first, but this makes the ordering correct by construction.)
- **Always observe the outcome.** A close that faults within the wait is caught and logged via `InternalLogger`; on timeout a fault-observing continuation is attached so a later fault can never become an unobserved task exception, plus a warning is logged. `CloseTarget` never throws.
- **Sensible bounded wait.** The arbitrary 500 ms cap → a 5 s bound generous enough for a healthy-but-slow teardown. Because the outcome is *always* observed (even past the bound), the bound governs only how long shutdown blocks, never correctness — so the ServiceBus `DisposeAsync()` is no longer silently abandoned.
- `CloseTarget` stays synchronous (NLog signature) with a correct sync-over-async bridge.

## Tests (test-first; reverting the fix fails them)

Driven through the fakes + `LogFactory`:

- `Shutdown_WhenCloseAsyncThrows_IsLoggedAndDoesNotPropagate` — a 900 ms-then-throwing close is logged via `InternalLogger` and does **not** propagate (was a silent unobserved exception). *Fails pre-fix.*
- `Shutdown_SlowCloseIsAwaitedNotAbandoned` — an 800 ms close runs to completion during shutdown; for ServiceBus the client dispose completes too. *Fails pre-fix (abandoned at 500 ms).*
- `Shutdown_FlushesQueuedEventsBeforeClosingConnection` — invariant guard: all events sent, none over a closed connection. *Passes pre- and post-fix* — documents the disproven premise; not a revert-fails test.

## Verification

- `EventHubTarget` tests: **10/10**. `ServiceBusTarget` tests: **9/9** (`DOTNET_ROLL_FORWARD=Major`, net8 target on net9/10 runtimes).
- Release build of both `src` projects across `netstandard2.0; net8.0; net10.0`: 0 warnings, 0 errors. `TreatWarningsAsErrors` not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)