### PR TITLE
Fix AMQP client-secret auth silently dropping WebSockets/proxy options (ServiceBus + EventHub)

### DIFF
--- a/src/NLog.Extensions.AzureEventHub/EventHubTarget.cs
+++ b/src/NLog.Extensions.AzureEventHub/EventHubTarget.cs
@@ -608,7 +608,7 @@ namespace NLog.Targets
                 else if (!string.IsNullOrEmpty(clientAuthId) && !string.IsNullOrEmpty(clientAuthSecret) && !string.IsNullOrEmpty(tenantIdentity))
                 {
                     var tokenCredentials = new Azure.Identity.ClientSecretCredential(tenantIdentity, clientAuthId, clientAuthSecret);
-                    _client = new Azure.Messaging.EventHubs.Producer.EventHubProducerClient(serviceUri, eventHubName, tokenCredentials);
+                    _client = new Azure.Messaging.EventHubs.Producer.EventHubProducerClient(serviceUri, eventHubName, tokenCredentials, options);
                 }
                 else
                 {

--- a/src/NLog.Extensions.AzureServiceBus/ServiceBusTarget.cs
+++ b/src/NLog.Extensions.AzureServiceBus/ServiceBusTarget.cs
@@ -688,7 +688,7 @@ namespace NLog.Targets
                 else if (!string.IsNullOrEmpty(clientAuthId) && !string.IsNullOrEmpty(clientAuthSecret) && !string.IsNullOrEmpty(tenantIdentity))
                 {
                     var tokenCredentials = new Azure.Identity.ClientSecretCredential(tenantIdentity, clientAuthId, clientAuthSecret);
-                    _client = new ServiceBusClient(serviceUri, tokenCredentials);
+                    _client = new ServiceBusClient(serviceUri, tokenCredentials, options);
                 }
                 else
                 {


### PR DESCRIPTION
## Problem

Under **client-secret** (`ClientSecretCredential`) auth, both ServiceBus and EventHub built their AMQP client **without the configured `options`** object. That object carries `useWebSockets` (transport type), the proxy/`WebProxy`, the custom endpoint address, and the producer identifier — so all of those were **silently ignored** when authenticating with a client id + secret.

The bug is asymmetry within the same `Connect` method: every other auth branch (connection string, SAS, named-key, and managed-identity) passes `options`; only the client-secret branch dropped it.

- `ServiceBusTarget.cs` — `new ServiceBusClient(serviceUri, tokenCredentials)` → now `(serviceUri, tokenCredentials, options)` (cf. the managed-identity sibling immediately below it)
- `EventHubTarget.cs` — `new EventHubProducerClient(serviceUri, eventHubName, tokenCredentials)` → now `(..., tokenCredentials, options)` (cf. the managed-identity sibling)

## Fix

Pass the existing `options` local into both constructors, matching the managed-identity sibling branch. Root cause is the two constructor calls; the credential dispatch is otherwise untouched.

This mirrors **#200**, which fixed the identical bug on the Queue target. EventHub was missed by that original audit — it was confirmed here by reading the client-secret branch against its options-carrying managed-identity sibling.

## Verification

- Both `src` projects build clean (`netstandard2.0;net8.0;net10.0`), 0 warnings.
- **Verified by inspection** (symmetry with the options-carrying sibling branches + #200's Queue precedent). The existing target tests don't exercise the `Connect` credential branches, and a faithful assertion would require a service-layer seam that doesn't exist today. Building that harness for a 2-line plumbing fix is out of scope; add it when someone is already adding Connect-branch coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)