### PR TITLE
Batch EventGrid sends: N HTTP requests per flush → 1

### DIFF
--- a/src/NLog.Extensions.AzureEventGrid/EventGridTarget.cs
+++ b/src/NLog.Extensions.AzureEventGrid/EventGridTarget.cs
@@ -278,6 +278,42 @@ namespace NLog.Targets
             }
         }
 
+        /// <summary>
+        /// Override this to provide async task for writing a batch of logevents in a single request.
+        /// </summary>
+        /// <param name="logEvents">The log events.</param>
+        /// <param name="cancellationToken">Token to cancel the asynchronous operation.</param>
+        protected override Task WriteAsyncTask(IList<LogEventInfo> logEvents, CancellationToken cancellationToken)
+        {
+            if (logEvents.Count == 1)
+                return WriteAsyncTask(logEvents[0], cancellationToken);  // single-event path, NLog uses it for count==1
+
+            // ponytail: one SendEventsAsync per flush; NLog BatchSize bounds it. Split by size only if the
+            // ~1MB EventGrid limit is actually hit.
+            try
+            {
+                if (CloudEventSource is null)
+                {
+                    var gridEvents = new List<EventGridEvent>(logEvents.Count);
+                    for (int i = 0; i < logEvents.Count; ++i)
+                        gridEvents.Add(CreateGridEvent(logEvents[i]));
+                    return _eventGridService.SendEventsAsync(gridEvents, cancellationToken);
+                }
+                else
+                {
+                    var cloudEvents = new List<CloudEvent>(logEvents.Count);
+                    for (int i = 0; i < logEvents.Count; ++i)
+                        cloudEvents.Add(CreateCloudEvent(logEvents[i]));
+                    return _eventGridService.SendEventsAsync(cloudEvents, cancellationToken);
+                }
+            }
+            catch (Exception ex)
+            {
+                InternalLogger.Error(ex, "AzureEventGridTarget(Name={0}): Failed sending {1} logevents to Topic={2}", Name, logEvents.Count, _eventGridService?.Topic);
+                throw;
+            }
+        }
+
         internal sealed class EventGridService : IEventGridService, IDisposable
         {
             EventGridPublisherClient _client;
@@ -338,6 +374,16 @@ namespace NLog.Targets
             public Task SendEventAsync(CloudEvent cloudEvent, CancellationToken cancellationToken)
             {
                 return _client.SendEventAsync(cloudEvent, cancellationToken);
+            }
+
+            public Task SendEventsAsync(IEnumerable<EventGridEvent> gridEvents, CancellationToken cancellationToken)
+            {
+                return _client.SendEventsAsync(gridEvents, cancellationToken);
+            }
+
+            public Task SendEventsAsync(IEnumerable<CloudEvent> cloudEvents, CancellationToken cancellationToken)
+            {
+                return _client.SendEventsAsync(cloudEvents, cancellationToken);
             }
         }
 

--- a/src/NLog.Extensions.AzureEventGrid/EventGridTarget.cs
+++ b/src/NLog.Extensions.AzureEventGrid/EventGridTarget.cs
@@ -23,6 +23,10 @@ namespace NLog.Targets
         private readonly IEventGridService _eventGridService;
         private readonly char[] _reusableEncodingBuffer = new char[32 * 1024];  // Avoid large-object-heap
 
+        private const int DefaultMaxBatchSizeBytes = 1000 * 1000;   // ~1MB EventGrid request limit, with headroom under the hard cap
+        private const int MaxEventsPerRequest = 1000;               // EventGrid namespace cap (custom topics allow 5000); 1000 is safe everywhere
+        private const int EventEnvelopeOverheadBytes = 512;         // id (GUID) + timestamp + JSON field names/punctuation per event
+
         /// <summary>
         /// The topic endpoint. For example, "https://TOPIC-NAME.REGION-NAME-1.eventgrid.azure.net/api/events"
         /// </summary>
@@ -74,6 +78,13 @@ namespace NLog.Targets
         /// The schema version of the data object.
         /// </summary>
         public Layout DataSchema { get; set; }
+
+        /// <summary>
+        /// Maximum estimated size (in bytes) of a single batched publish request. When a flush (bounded by
+        /// <see cref="AsyncTaskTarget.BatchSize"/>) would exceed this, it is split across multiple requests so
+        /// each stays under Azure Event Grid's ~1 MB per-request limit. Default 1,000,000.
+        /// </summary>
+        public int MaxBatchSizeBytes { get; set; } = DefaultMaxBatchSizeBytes;
 
         /// <summary>
         /// TenantId for <see cref="Azure.Identity.DefaultAzureCredentialOptions"/>. Used with DefaultAzureCredential authentication when connecting to the Event Grid topic endpoint.
@@ -288,8 +299,6 @@ namespace NLog.Targets
             if (logEvents.Count == 1)
                 return WriteAsyncTask(logEvents[0], cancellationToken);  // single-event path, NLog uses it for count==1
 
-            // ponytail: one SendEventsAsync per flush; NLog BatchSize bounds it. Split by size only if the
-            // ~1MB EventGrid limit is actually hit.
             try
             {
                 if (CloudEventSource is null)
@@ -297,14 +306,14 @@ namespace NLog.Targets
                     var gridEvents = new List<EventGridEvent>(logEvents.Count);
                     for (int i = 0; i < logEvents.Count; ++i)
                         gridEvents.Add(CreateGridEvent(logEvents[i]));
-                    return _eventGridService.SendEventsAsync(gridEvents, cancellationToken);
+                    return SendInBatches(gridEvents, EstimateGridEventBytes, (batch, ct) => _eventGridService.SendEventsAsync(batch, ct), cancellationToken);
                 }
                 else
                 {
                     var cloudEvents = new List<CloudEvent>(logEvents.Count);
                     for (int i = 0; i < logEvents.Count; ++i)
                         cloudEvents.Add(CreateCloudEvent(logEvents[i]));
-                    return _eventGridService.SendEventsAsync(cloudEvents, cancellationToken);
+                    return SendInBatches(cloudEvents, EstimateCloudEventBytes, (batch, ct) => _eventGridService.SendEventsAsync(batch, ct), cancellationToken);
                 }
             }
             catch (Exception ex)
@@ -431,6 +440,68 @@ namespace NLog.Targets
             var gridEvent = new EventGridEvent(eventSubject, eventType, eventDataSchema, new BinaryData(EncodeToUTF8(eventDataBody)));
             gridEvent.EventTime = logEvent.TimeStamp.ToUniversalTime();
             return gridEvent;
+        }
+
+        // ponytail: EventGrid's SDK has no TryAdd batch-builder (unlike the ServiceBus/EventHub SDKs), so the
+        // request size is a conservative estimate that over-counts (per-event envelope allowance + base64
+        // inflation) to stay safely under the limit and never under-count into a 413. The cap default leaves
+        // headroom under EventGrid's ~1MB hard limit. Swap in exact serialization accounting only if the
+        // estimate ever proves too coarse in practice.
+        private Task SendInBatches<T>(IList<T> events, Func<T, long> estimateBytes, Func<IList<T>, CancellationToken, Task> sendBatch, CancellationToken cancellationToken)
+        {
+            long sizeLimit = MaxBatchSizeBytes > 0 ? MaxBatchSizeBytes : DefaultMaxBatchSizeBytes;
+
+            List<Task> sendTasks = null;
+            var batch = new List<T>();
+            long batchBytes = 0;
+
+            for (int i = 0; i < events.Count; ++i)
+            {
+                long eventBytes = estimateBytes(events[i]);
+                if (batch.Count > 0 && (batch.Count >= MaxEventsPerRequest || batchBytes + eventBytes > sizeLimit))
+                {
+                    if (sendTasks == null)
+                        sendTasks = new List<Task>();
+                    sendTasks.Add(sendBatch(batch, cancellationToken));
+                    batch = new List<T>();
+                    batchBytes = 0;
+                }
+
+                batch.Add(events[i]);   // a single event over the limit is still sent alone - the service is the authority, not our estimate
+                batchBytes += eventBytes;
+            }
+
+            if (sendTasks == null)
+                return sendBatch(batch, cancellationToken);   // common case: the whole flush fits one request
+
+            sendTasks.Add(sendBatch(batch, cancellationToken));
+            return Task.WhenAll(sendTasks);
+        }
+
+        private static long EstimateGridEventBytes(EventGridEvent gridEvent)
+        {
+            long bytes = EventEnvelopeOverheadBytes;
+            if (gridEvent.Data != null)
+                bytes += EstimateDataBytes(gridEvent.Data.ToMemory().Length, false);   // EventGridEvent has no binary data format
+            bytes += (gridEvent.Subject?.Length ?? 0) + (gridEvent.EventType?.Length ?? 0) + (gridEvent.DataVersion?.Length ?? 0);
+            return bytes;
+        }
+
+        private long EstimateCloudEventBytes(CloudEvent cloudEvent)
+        {
+            long bytes = EventEnvelopeOverheadBytes;
+            if (cloudEvent.Data != null)
+                bytes += EstimateDataBytes(cloudEvent.Data.ToMemory().Length, _dataFormatJson != true);   // binary data is base64-encoded in the envelope
+            bytes += (cloudEvent.Source?.Length ?? 0) + (cloudEvent.Type?.Length ?? 0) + (cloudEvent.DataSchema?.Length ?? 0);
+            foreach (var attribute in cloudEvent.ExtensionAttributes)
+                bytes += attribute.Key.Length + (attribute.Value?.ToString()?.Length ?? 0) + 8;   // "key":"value",
+            return bytes;
+        }
+
+        private static long EstimateDataBytes(int rawDataLength, bool binary)
+        {
+            // Conservative: binary is base64-encoded (~4/3), JSON/text gets a margin for string escaping.
+            return binary ? (rawDataLength * 4L / 3 + 4) : (rawDataLength + rawDataLength / 8 + 16);
         }
 
         private byte[] EncodeToUTF8(string eventDataBody)

--- a/src/NLog.Extensions.AzureEventGrid/IEventGridService.cs
+++ b/src/NLog.Extensions.AzureEventGrid/IEventGridService.cs
@@ -1,6 +1,7 @@
 ﻿using Azure.Messaging;
 using Azure.Messaging.EventGrid;
 using NLog.Extensions.AzureBlobStorage;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,5 +16,9 @@ namespace NLog.Extensions.AzureStorage
         Task SendEventAsync(EventGridEvent gridEvent, CancellationToken cancellationToken);
 
         Task SendEventAsync(CloudEvent cloudEvent, CancellationToken cancellationToken);
+
+        Task SendEventsAsync(IEnumerable<EventGridEvent> gridEvents, CancellationToken cancellationToken);
+
+        Task SendEventsAsync(IEnumerable<CloudEvent> cloudEvents, CancellationToken cancellationToken);
     }
 }

--- a/test/NLog.Extensions.AzureEventGrid.Tests/EventGridBatchingTests.cs
+++ b/test/NLog.Extensions.AzureEventGrid.Tests/EventGridBatchingTests.cs
@@ -20,7 +20,8 @@ namespace NLog.Extensions.AzureEventGrid.Tests
                 Topic = "${var:TopicUrl}",
                 Layout = "${message}",
                 BatchSize = 100000,          // deliver the whole flush in one WriteAsyncTask call
-                TaskDelayMilliseconds = 1,
+                TaskDelayMilliseconds = 1000,  // long enough that the timer never flushes mid-loop; Flush() forces the send
+
             };
             if (maxBatchSizeBytes > 0)
                 target.MaxBatchSizeBytes = maxBatchSizeBytes;

--- a/test/NLog.Extensions.AzureEventGrid.Tests/EventGridBatchingTests.cs
+++ b/test/NLog.Extensions.AzureEventGrid.Tests/EventGridBatchingTests.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+using NLog.Targets;
+using Xunit;
+
+namespace NLog.Extensions.AzureEventGrid.Tests
+{
+    // A flush of N events used to send N separate HTTP requests, because the target overrode only the
+    // single-event WriteAsyncTask and the base IList override chains one SendEventAsync per event. With the
+    // IList override + batched SendEventsAsync, the whole flush is one request. Reverting the IList override
+    // makes SendCallCount jump back to N and fails these tests.
+    public class EventGridBatchingTests
+    {
+        private static (LogFactory factory, EventGridServiceMock svc, Logger logger) Build(bool cloudEvents)
+        {
+            var logFactory = new LogFactory();
+            var logConfig = new Config.LoggingConfiguration(logFactory);
+            logConfig.Variables["TopicUrl"] = nameof(EventGridBatchingTests);
+            var svc = new EventGridServiceMock();
+            var target = new EventGridTarget(svc)
+            {
+                Topic = "${var:TopicUrl}",
+                Layout = "${message}",
+                BatchSize = 100000,          // deliver the whole flush in one WriteAsyncTask call
+                TaskDelayMilliseconds = 1,
+            };
+            if (cloudEvents)
+                target.CloudEventSource = "${logger}";
+            else
+                target.GridEventSubject = "${logger}";
+            logConfig.AddRuleForAllLevels(target);
+            logFactory.Configuration = logConfig;
+            return (logFactory, svc, logFactory.GetLogger(nameof(EventGridBatchingTests)));
+        }
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(50)]
+        [InlineData(250)]
+        public void BatchedGridEvents_SendOneRequest(int count)
+        {
+            var (factory, svc, logger) = Build(cloudEvents: false);
+
+            for (int i = 0; i < count; ++i)
+                logger.Info("m-" + i);
+            factory.Flush();
+
+            Assert.Equal(1, svc.SendCallCount);              // one batched request, not N
+            Assert.Equal(count, svc.GridEvents.Count);       // every event delivered
+            Assert.Empty(svc.CloudEvents);
+        }
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(50)]
+        [InlineData(250)]
+        public void BatchedCloudEvents_SendOneRequest(int count)
+        {
+            var (factory, svc, logger) = Build(cloudEvents: true);
+
+            for (int i = 0; i < count; ++i)
+                logger.Info("m-" + i);
+            factory.Flush();
+
+            Assert.Equal(1, svc.SendCallCount);              // one batched request, not N
+            Assert.Equal(count, svc.CloudEvents.Count);      // every event delivered
+            Assert.Empty(svc.GridEvents);
+        }
+    }
+}

--- a/test/NLog.Extensions.AzureEventGrid.Tests/EventGridBatchingTests.cs
+++ b/test/NLog.Extensions.AzureEventGrid.Tests/EventGridBatchingTests.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using NLog.Targets;
 using Xunit;
 
@@ -10,7 +9,7 @@ namespace NLog.Extensions.AzureEventGrid.Tests
     // makes SendCallCount jump back to N and fails these tests.
     public class EventGridBatchingTests
     {
-        private static (LogFactory factory, EventGridServiceMock svc, Logger logger) Build(bool cloudEvents)
+        private static (LogFactory factory, EventGridServiceMock svc, Logger logger) Build(bool cloudEvents, int maxBatchSizeBytes = 0)
         {
             var logFactory = new LogFactory();
             var logConfig = new Config.LoggingConfiguration(logFactory);
@@ -23,6 +22,8 @@ namespace NLog.Extensions.AzureEventGrid.Tests
                 BatchSize = 100000,          // deliver the whole flush in one WriteAsyncTask call
                 TaskDelayMilliseconds = 1,
             };
+            if (maxBatchSizeBytes > 0)
+                target.MaxBatchSizeBytes = maxBatchSizeBytes;
             if (cloudEvents)
                 target.CloudEventSource = "${logger}";
             else
@@ -64,6 +65,60 @@ namespace NLog.Extensions.AzureEventGrid.Tests
             Assert.Equal(1, svc.SendCallCount);              // one batched request, not N
             Assert.Equal(count, svc.CloudEvents.Count);      // every event delivered
             Assert.Empty(svc.GridEvents);
+        }
+
+        // A flush whose combined payload exceeds the ~1MB request limit must be split across requests so it
+        // is never rejected wholesale - and nothing may be lost in the split. EventGrid has no SDK batch
+        // builder, so the target estimates size conservatively; here large events force more than one request.
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void OversizedFlush_SplitsAcrossRequests_NoLoss(bool cloudEvents)
+        {
+            const int count = 10;
+            var (factory, svc, logger) = Build(cloudEvents, maxBatchSizeBytes: 7000);
+
+            var bigMessage = new string('x', 2000);
+            for (int i = 0; i < count; ++i)
+                logger.Info(bigMessage);
+            factory.Flush();
+
+            var delivered = cloudEvents ? svc.CloudEvents.Count : svc.GridEvents.Count;
+            Assert.True(svc.SendCallCount > 1, $"expected a split into multiple requests, got {svc.SendCallCount}");
+            Assert.Equal(count, delivered);                  // nothing lost in the split
+        }
+
+        // EventGrid caps events per request; a flush of many tiny events (under the byte limit) must still be
+        // chunked by count so no single request exceeds the cap.
+        [Fact]
+        public void ManyTinyEvents_SplitByEventCount_NoLoss()
+        {
+            const int count = 2500;
+            var (factory, svc, logger) = Build(cloudEvents: false, maxBatchSizeBytes: int.MaxValue);  // isolate the count cap
+
+            for (int i = 0; i < count; ++i)
+                logger.Info("m-" + i);
+            factory.Flush();
+
+            Assert.True(svc.SendCallCount > 1, "expected multiple requests once the per-request event cap is hit");
+            Assert.All(svc.SendBatchSizes, n => Assert.InRange(n, 1, 1000));   // no batched request exceeds the cap
+            Assert.Equal(count, svc.GridEvents.Count);                         // nothing lost
+        }
+
+        // A single event larger than the cap can't be made to fit - but it must still be sent (alone), and it
+        // must not drag its in-flush siblings down with it (the regression #202 guards against elsewhere).
+        [Fact]
+        public void SingleOversizedEvent_SentAlone_SiblingsStillDelivered()
+        {
+            var (factory, svc, logger) = Build(cloudEvents: false, maxBatchSizeBytes: 4000);
+
+            logger.Info(new string('x', 8000));   // alone exceeds the cap
+            logger.Info("small-1");
+            logger.Info("small-2");
+            factory.Flush();
+
+            Assert.Equal(3, svc.GridEvents.Count);          // oversized event not dropped, siblings delivered
+            Assert.True(svc.SendCallCount >= 2, "the oversized event should be isolated into its own request");
         }
     }
 }

--- a/test/NLog.Extensions.AzureEventGrid.Tests/EventGridServiceMock.cs
+++ b/test/NLog.Extensions.AzureEventGrid.Tests/EventGridServiceMock.cs
@@ -34,68 +34,60 @@ namespace NLog.Extensions.AzureEventGrid.Tests
             Topic = topic;
         }
 
-        public Task SendEventAsync(EventGridEvent gridEvent, CancellationToken cancellationToken)
+        public async Task SendEventAsync(EventGridEvent gridEvent, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(Topic))
                 throw new InvalidOperationException("TopicUri not connected");
 
-            return Task.Delay(10, cancellationToken).ContinueWith(t =>
+            await Task.Delay(10, cancellationToken).ConfigureAwait(false);   // canceled delay throws here, so a canceled send records nothing
+            lock (GridEvents)
             {
-                lock (GridEvents)
-                {
-                    SendCallCount++;
-                    GridEvents.Add(gridEvent);
-                }
-            });
+                SendCallCount++;
+                GridEvents.Add(gridEvent);
+            }
         }
 
-        public Task SendEventAsync(CloudEvent cloudEvent, CancellationToken cancellationToken)
+        public async Task SendEventAsync(CloudEvent cloudEvent, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(Topic))
                 throw new InvalidOperationException("TopicUri not connected");
 
-            return Task.Delay(10, cancellationToken).ContinueWith(t =>
+            await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+            lock (CloudEvents)
             {
-                lock (CloudEvents)
-                {
-                    SendCallCount++;
-                    CloudEvents.Add(cloudEvent);
-                }
-            });
+                SendCallCount++;
+                CloudEvents.Add(cloudEvent);
+            }
         }
 
-        public Task SendEventsAsync(IEnumerable<EventGridEvent> gridEvents, CancellationToken cancellationToken)
+        public async Task SendEventsAsync(IEnumerable<EventGridEvent> gridEvents, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(Topic))
                 throw new InvalidOperationException("TopicUri not connected");
 
             var batch = gridEvents.ToList();
-            return Task.Delay(10, cancellationToken).ContinueWith(t =>
+            await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+            lock (GridEvents)
             {
-                lock (GridEvents)
-                {
-                    SendCallCount++;   // one batched send => one request
-                    SendBatchSizes.Add(batch.Count);
-                    GridEvents.AddRange(batch);
-                }
-            });
+                SendCallCount++;   // one batched send => one request
+                SendBatchSizes.Add(batch.Count);
+                GridEvents.AddRange(batch);
+            }
         }
 
-        public Task SendEventsAsync(IEnumerable<CloudEvent> cloudEvents, CancellationToken cancellationToken)
+        public async Task SendEventsAsync(IEnumerable<CloudEvent> cloudEvents, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(Topic))
                 throw new InvalidOperationException("TopicUri not connected");
 
             var batch = cloudEvents.ToList();
-            return Task.Delay(10, cancellationToken).ContinueWith(t =>
+            await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+            lock (CloudEvents)
             {
-                lock (CloudEvents)
-                {
-                    SendCallCount++;   // one batched send => one request
-                    SendBatchSizes.Add(batch.Count);
-                    CloudEvents.AddRange(batch);
-                }
-            });
+                SendCallCount++;   // one batched send => one request
+                SendBatchSizes.Add(batch.Count);
+                CloudEvents.AddRange(batch);
+            }
         }
 
         public string PeekLastGridEvent()

--- a/test/NLog.Extensions.AzureEventGrid.Tests/EventGridServiceMock.cs
+++ b/test/NLog.Extensions.AzureEventGrid.Tests/EventGridServiceMock.cs
@@ -23,6 +23,9 @@ namespace NLog.Extensions.AzureEventGrid.Tests
 
         public List<CloudEvent> CloudEvents { get; } = new List<CloudEvent>();
 
+        /// <summary>Number of service send calls (one per HTTP request). One batched flush => 1.</summary>
+        public int SendCallCount { get; private set; }
+
         public void Connect(string topic, string tenantIdentity, string managedIdentityResourceId, string managedIdentityClientId, string sharedAccessSignature, string accessKey, string clientAuthId, string clientAuthSecret, ProxySettings proxySettings = null)
         {
             Topic = topic;
@@ -36,7 +39,10 @@ namespace NLog.Extensions.AzureEventGrid.Tests
             return Task.Delay(10, cancellationToken).ContinueWith(t =>
             {
                 lock (GridEvents)
+                {
+                    SendCallCount++;
                     GridEvents.Add(gridEvent);
+                }
             });
         }
 
@@ -48,7 +54,42 @@ namespace NLog.Extensions.AzureEventGrid.Tests
             return Task.Delay(10, cancellationToken).ContinueWith(t =>
             {
                 lock (CloudEvents)
+                {
+                    SendCallCount++;
                     CloudEvents.Add(cloudEvent);
+                }
+            });
+        }
+
+        public Task SendEventsAsync(IEnumerable<EventGridEvent> gridEvents, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(Topic))
+                throw new InvalidOperationException("TopicUri not connected");
+
+            var batch = gridEvents.ToList();
+            return Task.Delay(10, cancellationToken).ContinueWith(t =>
+            {
+                lock (GridEvents)
+                {
+                    SendCallCount++;   // one batched send => one request
+                    GridEvents.AddRange(batch);
+                }
+            });
+        }
+
+        public Task SendEventsAsync(IEnumerable<CloudEvent> cloudEvents, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(Topic))
+                throw new InvalidOperationException("TopicUri not connected");
+
+            var batch = cloudEvents.ToList();
+            return Task.Delay(10, cancellationToken).ContinueWith(t =>
+            {
+                lock (CloudEvents)
+                {
+                    SendCallCount++;   // one batched send => one request
+                    CloudEvents.AddRange(batch);
+                }
             });
         }
 

--- a/test/NLog.Extensions.AzureEventGrid.Tests/EventGridServiceMock.cs
+++ b/test/NLog.Extensions.AzureEventGrid.Tests/EventGridServiceMock.cs
@@ -26,6 +26,9 @@ namespace NLog.Extensions.AzureEventGrid.Tests
         /// <summary>Number of service send calls (one per HTTP request). One batched flush => 1.</summary>
         public int SendCallCount { get; private set; }
 
+        /// <summary>Event count of each batched send call, in order. One entry per request issued.</summary>
+        public List<int> SendBatchSizes { get; } = new List<int>();
+
         public void Connect(string topic, string tenantIdentity, string managedIdentityResourceId, string managedIdentityClientId, string sharedAccessSignature, string accessKey, string clientAuthId, string clientAuthSecret, ProxySettings proxySettings = null)
         {
             Topic = topic;
@@ -72,6 +75,7 @@ namespace NLog.Extensions.AzureEventGrid.Tests
                 lock (GridEvents)
                 {
                     SendCallCount++;   // one batched send => one request
+                    SendBatchSizes.Add(batch.Count);
                     GridEvents.AddRange(batch);
                 }
             });
@@ -88,6 +92,7 @@ namespace NLog.Extensions.AzureEventGrid.Tests
                 lock (CloudEvents)
                 {
                     SendCallCount++;   // one batched send => one request
+                    SendBatchSizes.Add(batch.Count);
                     CloudEvents.AddRange(batch);
                 }
             });


### PR DESCRIPTION
## Problem

`EventGridTarget` overrode only the single-event `WriteAsyncTask(LogEventInfo)`. NLog's base `WriteAsyncTask(IList<LogEventInfo>)` chains **one `SendEventAsync` per event**, so a flush of N log events fired **N separate HTTP requests** to Event Grid — even though `EventGridPublisherClient` already exposes a batched `SendEventsAsync(IEnumerable<...>)`.

## Fix

- Override `WriteAsyncTask(IList<LogEventInfo>, CancellationToken)` to build the flush and send it batched, mirroring the single-event shape: `CreateGridEvent` when `CloudEventSource` is null, else `CreateCloudEvent`. `Count == 1` still routes to the existing single-event override.
- Add matching `SendEventsAsync` overloads to `IEventGridService` / `EventGridService`, delegating to `EventGridPublisherClient.SendEventsAsync(IEnumerable<EventGridEvent>)` and `(IEnumerable<CloudEvent>)`.

Net effect: **N requests → 1 batched request** per flush (when the flush fits one request).

## Size-aware splitting (so batching is safe to turn up)

NLog's `BatchSize` bounds a flush by **event count, not bytes**. With `BatchSize > 1`, a flush of larger events can exceed Event Grid's **~1 MB per-request limit** — and a single batched send would then have the service reject the **whole flush** (413), one oversized portion sinking all its siblings (the regression class #202 fixed for DataTables). For a library, a throughput knob shouldn't become silent whole-flush data loss, and the sibling targets already guard this (ServiceBus/EventHub size-split in #201).

Event Grid's SDK has **no** `TryAdd`/`CreateBatch` builder (the #201 mechanism), so the split is **predictive**:

- Accumulate events into sub-batches under a **conservative byte estimate** (per-event envelope allowance + base64 inflation, biased to over-count so it never under-counts into a 413) and the per-request event cap; send each sub-batch as one request.
- A single event larger than the cap is still **sent alone** — the service is the authority, not our estimate — so its in-flush siblings are never dropped.
- Common case (whole flush fits) stays **one request, zero overhead**.
- New **`MaxBatchSizeBytes`** knob (default 1,000,000), mirroring the `ServiceBusTarget` property.

The conservative estimate (no SDK builder to lean on) is marked with a `// ponytail:` comment naming the ceiling and the upgrade path (exact serialization accounting) if it ever proves too coarse.

## Tests

`EventGridBatchingTests` (`EventGridServiceMock` gained a `SendCallCount` + per-request `SendBatchSizes`):

- **One batched request, not N** — N events in one flush → exactly one send carrying all N (EventGridEvent and CloudEvent modes, N = 2/50/250). Reverting the `IList` override flips `SendCallCount` back to N and fails (verified).
- **Oversized flush splits across requests, no loss** — large events force >1 request, all delivered (both modes).
- **Many tiny events split by the per-request event cap**, no loss.
- **Single oversized event is sent alone**, siblings still delivered.

Azurite has no Event Grid emulator, so the mock-based tests are the reproduction/verification vehicle. All EventGrid tests pass; `src` builds warning-clean on `netstandard2.0;net8.0;net10.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)