### PR TITLE
Bump storage package versions for the #192–#206 fixes

### DIFF
--- a/src/NLog.Extensions.AzureBlobStorage/NLog.Extensions.AzureBlobStorage.csproj
+++ b/src/NLog.Extensions.AzureBlobStorage/NLog.Extensions.AzureBlobStorage.csproj
@@ -9,7 +9,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
-    <Version>4.7.1</Version>
+    <Version>4.7.2</Version>
 
     <Description>NLog BlobStorageTarget for writing to Azure Cloud Blob Storage</Description>
     <Authors>jdetmar</Authors>
@@ -24,7 +24,9 @@
     <RepositoryUrl>https://github.com/JDetmar/NLog.Extensions.AzureStorage.git</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>
-- Updated Azure.Identity to ver 1.17.1 (Security fix)
+- Fixed silent log loss from an un-awaited nested Task on the cache-miss path (#194)
+- Fixed AzureStorageNameCache thread-safety under concurrent use (#196)
+- Fixed HttpClient/transport leak when connecting through a proxy (#200)
 
 Docs: https://github.com/JDetmar/NLog.Extensions.AzureStorage/blob/master/src/NLog.Extensions.AzureBlobStorage/README.md
     </PackageReleaseNotes>

--- a/src/NLog.Extensions.AzureDataTables/NLog.Extensions.AzureDataTables.csproj
+++ b/src/NLog.Extensions.AzureDataTables/NLog.Extensions.AzureDataTables.csproj
@@ -9,7 +9,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
-    <Version>4.7.1</Version>
+    <Version>4.7.2</Version>
 
     <Description>NLog DataTablesTarget for writing to Azure Tables in Azure storage accounts or Azure Cosmos DB table API</Description>
     <Authors>jdetmar</Authors>
@@ -24,7 +24,14 @@
     <RepositoryUrl>https://github.com/JDetmar/NLog.Extensions.AzureStorage.git</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>
-- Updated Azure.Identity to ver 1.17.1 (Security fix)
+- Fixed CheckAndRepairTableNamingRules returning the un-repaired table name (#192)
+- Fixed off-by-one truncation of max-length table string values (#193)
+- Fixed silent log loss from an un-awaited nested Task on the cache-miss path (#194)
+- Fixed AzureStorageNameCache thread-safety under concurrent use (#196)
+- Sanitize Table PartitionKey/RowKey to prevent whole-batch loss (#198)
+- Fixed HttpClient/transport leak when connecting through a proxy (#200)
+- Fixed batch integrity so one un-renderable event no longer sinks the whole atomic batch (#202)
+- Truncate over-long PartitionKey/RowKey to 512 chars to prevent whole-batch loss (#206)
 
 Docs: https://github.com/JDetmar/NLog.Extensions.AzureStorage/blob/master/src/NLog.Extensions.AzureDataTables/README.md
     </PackageReleaseNotes>

--- a/src/NLog.Extensions.AzureDataTables/NLog.Extensions.AzureDataTables.csproj
+++ b/src/NLog.Extensions.AzureDataTables/NLog.Extensions.AzureDataTables.csproj
@@ -28,10 +28,10 @@
 - Fixed off-by-one truncation of max-length table string values (#193)
 - Fixed silent log loss from an un-awaited nested Task on the cache-miss path (#194)
 - Fixed AzureStorageNameCache thread-safety under concurrent use (#196)
-- Sanitize Table PartitionKey/RowKey to prevent whole-batch loss (#198)
+- Sanitized table PartitionKey/RowKey to prevent whole-batch loss (#198)
 - Fixed HttpClient/transport leak when connecting through a proxy (#200)
 - Fixed batch integrity so one un-renderable event no longer sinks the whole atomic batch (#202)
-- Truncate over-long PartitionKey/RowKey to 512 chars to prevent whole-batch loss (#206)
+- Truncated over-long PartitionKey/RowKey to 512 chars to prevent whole-batch loss (#206)
 
 Docs: https://github.com/JDetmar/NLog.Extensions.AzureStorage/blob/master/src/NLog.Extensions.AzureDataTables/README.md
     </PackageReleaseNotes>

--- a/src/NLog.Extensions.AzureEventGrid/NLog.Extensions.AzureEventGrid.csproj
+++ b/src/NLog.Extensions.AzureEventGrid/NLog.Extensions.AzureEventGrid.csproj
@@ -9,7 +9,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
-    <Version>4.7.1</Version>
+    <Version>4.8.0</Version>
 
     <Description>NLog EventGridTarget for writing to Azure Event Grid</Description>
     <Authors>jdetmar</Authors>
@@ -24,7 +24,8 @@
     <RepositoryUrl>https://github.com/JDetmar/NLog.Extensions.AzureStorage.git</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>
-- Updated Azure.Identity to ver 1.17.1 (Security fix)
+- Fixed HttpClient/transport leak when connecting through a proxy (#200)
+- Batch EventGrid sends: one HTTP request per flush instead of one per event (#205)
 
 Docs: https://github.com/JDetmar/NLog.Extensions.AzureStorage/blob/master/src/NLog.Extensions.AzureEventGrid/README.md
     </PackageReleaseNotes>

--- a/src/NLog.Extensions.AzureEventHub/NLog.Extensions.AzureEventHub.csproj
+++ b/src/NLog.Extensions.AzureEventHub/NLog.Extensions.AzureEventHub.csproj
@@ -26,7 +26,7 @@
     <PackageReleaseNotes>
 - Fixed batch-size estimate integer overflow (#197)
 - Redesigned batch splitting using the SDK native batch API to prevent log loss (#201)
-- Fixed shutdown teardown to observe CloseAsync outcome and bound the wait (#203)
+- Fixed shutdown to observe CloseAsync outcome and bound the wait (#203)
 - Fixed AMQP client-secret auth dropping WebSockets/proxy options (#204)
       
 Docs: https://github.com/JDetmar/NLog.Extensions.AzureStorage/blob/master/src/NLog.Extensions.AzureEventHub/README.md

--- a/src/NLog.Extensions.AzureEventHub/NLog.Extensions.AzureEventHub.csproj
+++ b/src/NLog.Extensions.AzureEventHub/NLog.Extensions.AzureEventHub.csproj
@@ -9,7 +9,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
-    <Version>4.7.1</Version>
+    <Version>4.7.2</Version>
 
     <Description>NLog EventHubTarget for writing to Azure Event Hubs datastreams</Description>
     <Authors>jdetmar</Authors>
@@ -24,7 +24,10 @@
     <RepositoryUrl>https://github.com/JDetmar/NLog.Extensions.AzureStorage.git</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>
-- Updated Azure.Identity to ver 1.17.1 (Security fix)
+- Fixed batch-size estimate integer overflow (#197)
+- Redesigned batch splitting using the SDK native batch API to prevent log loss (#201)
+- Fixed shutdown teardown to observe CloseAsync outcome and bound the wait (#203)
+- Fixed AMQP client-secret auth dropping WebSockets/proxy options (#204)
       
 Docs: https://github.com/JDetmar/NLog.Extensions.AzureStorage/blob/master/src/NLog.Extensions.AzureEventHub/README.md
     </PackageReleaseNotes>

--- a/src/NLog.Extensions.AzureQueueStorage/NLog.Extensions.AzureQueueStorage.csproj
+++ b/src/NLog.Extensions.AzureQueueStorage/NLog.Extensions.AzureQueueStorage.csproj
@@ -8,7 +8,7 @@
     <RepositoryBranch>master</RepositoryBranch>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>4.7.1</Version>
+    <Version>4.7.2</Version>
 
     <Description>NLog QueueStorageTarget for writing to Azure Cloud Queue Storage</Description>
     <Authors>jdetmar</Authors>
@@ -23,7 +23,9 @@
     <RepositoryUrl>https://github.com/JDetmar/NLog.Extensions.AzureStorage.git</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>
-- Updated Azure.Identity to ver 1.17.1 (Security fix)
+- Fixed silent log loss from an un-awaited nested Task on the cache-miss path (#194)
+- Fixed AzureStorageNameCache thread-safety under concurrent use (#196)
+- Fixed HttpClient/transport leak when connecting through a proxy (#200)
 
 Docs: https://github.com/JDetmar/NLog.Extensions.AzureStorage/blob/master/src/NLog.Extensions.AzureQueueStorage/README.md
     </PackageReleaseNotes>

--- a/src/NLog.Extensions.AzureServiceBus/NLog.Extensions.AzureServiceBus.csproj
+++ b/src/NLog.Extensions.AzureServiceBus/NLog.Extensions.AzureServiceBus.csproj
@@ -9,7 +9,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
-    <Version>4.7.1</Version>
+    <Version>4.7.2</Version>
 
     <Description>NLog ServiceBusTarget for writing to Azure Service Bus Topic or Queue</Description>
     <Authors>jdetmar</Authors>
@@ -24,7 +24,10 @@
     <RepositoryUrl>https://github.com/JDetmar/NLog.Extensions.AzureStorage.git</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>
-- Updated Azure.Identity to ver 1.17.1 (Security fix)
+- Fixed batch-size estimate integer overflow (#197)
+- Redesigned batch splitting using the SDK native batch API to prevent log loss (#201)
+- Fixed shutdown teardown to observe CloseAsync outcome and bound the wait (#203)
+- Fixed AMQP client-secret auth dropping WebSockets/proxy options (#204)
       
 Docs: https://github.com/JDetmar/NLog.Extensions.AzureStorage/blob/master/src/NLog.Extensions.AzureServiceBus/README.md
     </PackageReleaseNotes>

--- a/src/NLog.Extensions.AzureServiceBus/NLog.Extensions.AzureServiceBus.csproj
+++ b/src/NLog.Extensions.AzureServiceBus/NLog.Extensions.AzureServiceBus.csproj
@@ -26,7 +26,7 @@
     <PackageReleaseNotes>
 - Fixed batch-size estimate integer overflow (#197)
 - Redesigned batch splitting using the SDK native batch API to prevent log loss (#201)
-- Fixed shutdown teardown to observe CloseAsync outcome and bound the wait (#203)
+- Fixed shutdown to observe CloseAsync outcome and bound the wait (#203)
 - Fixed AMQP client-secret auth dropping WebSockets/proxy options (#204)
       
 Docs: https://github.com/JDetmar/NLog.Extensions.AzureStorage/blob/master/src/NLog.Extensions.AzureServiceBus/README.md


### PR DESCRIPTION
Version bumps for the batch of fixes merged since #192. Per-package semver — `publish.yml` versions and tags each package independently (`<PackageId>-<Version>`), so only changed packages bump and they don't need to stay aligned.

## Versions

| Package | Bump | Why |
|---|---|---|
| **EventGrid** | 4.7.1 → **4.8.0** (minor) | new public `MaxBatchSizeBytes` knob (#205) |
| **Blob, DataTables, EventHub, ServiceBus, QueueStorage** | 4.7.1 → **4.7.2** (patch) | bug fixes only, no public API change |

Only EventGrid added public surface (verified against the diff; the changed `IEventHubService`/`ICloudServiceBus`/`IEventGridService` interfaces are all `internal`). Subset releases have precedent here — e.g. 4.4.2 shipped to only Blob/EventHub/ServiceBus.

Also refreshed each package's `PackageReleaseNotes`, which still read "Updated Azure.Identity to ver 1.17.1" (the 4.7.1 note), replacing them with the fixes actually shipped per package (#192–#206).

## AzureAccessToken deliberately excluded

`NLog.Extensions.AzureAccessToken` got a fix in #195, but it is **not** bumped here:
- It's outside the solution and CI — not built, tested, or packed by the pipeline.
- It does not `dotnet pack` cleanly (`CS1591` on undocumented public members — pre-existing rot that went unnoticed precisely because nothing compiles it).
- It depends on the EOL'd `Microsoft.Azure.Services.AppAuthentication`, making it a deprecation candidate.

Its #195 fix, if shipped, will be handled as a separate decision (deprecate vs. modernize + manual release).

## Validation

Integration-tested before bumping:
- **Azurite** — Blob + DataTables suites green against the real emulator (key/name/length/batch/silent-loss fixes).
- **Live Azure** — EventHub & ServiceBus round-tripped 200/200 through the #201 batch-split rewrite; EventGrid batched send accepted (#205); #204 OAuth2-over-WebSockets proven via a same-binary differential (no-proxy succeeds, dead-proxy blocked → proxy/options now honored in the client-secret branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2xyUVGEM8F98StF62FF8z